### PR TITLE
Update umi_mem example signal names, and fix an 'assign to input' error

### DIFF
--- a/examples/umi_mem/umi_mem.v
+++ b/examples/umi_mem/umi_mem.v
@@ -5,13 +5,13 @@ module umi_mem #(
     input clk,
     input nreset,
 
-	input rx0_umi_valid,
-	input [255:0] rx0_umi_packet,
-	output rx0_umi_ready,
+    input rx0_umi_valid,
+    input [255:0] rx0_umi_packet,
+    output rx0_umi_ready,
 
-	output tx0_umi_valid,
-	output [255:0] tx0_umi_packet,
-	input tx0_umi_ready
+    output tx0_umi_valid,
+    output [255:0] tx0_umi_packet,
+    input tx0_umi_ready
 );
 
     wire [AW-1:0] addr;
@@ -19,7 +19,6 @@ module umi_mem #(
     wire read;
     wire [DW-1:0] write_data;
     wire [DW-1:0] read_data;
-    wire tx_ready_passthru;
 
     reg [DW-1:0] mem[1 << (AW - $clog2(DW))];
 
@@ -32,11 +31,11 @@ module umi_mem #(
 
         .umi_in_valid(rx0_umi_valid),
         .umi_in_packet(rx0_umi_packet),
-        .umi_out_ready(rx0_umi_ready),
+        .umi_in_ready(rx0_umi_ready),
 
         .umi_out_valid(tx0_umi_valid),
         .umi_out_packet(tx0_umi_packet),
-        .umi_in_ready(tx_ready_passthru),
+        .umi_out_ready(tx0_umi_ready),
 
         .addr(addr),
         .write(write),
@@ -48,9 +47,6 @@ module umi_mem #(
     // Truncate address - mem only supports DW-aligned accesses.
     wire [AW-1-$clog2(DW):0] mem_addr;
     assign mem_addr = addr[AW-1:$clog2(DW)];
-
-    // Pass-through signal for the 'umi_in_ready' signal, to prevent "assign to input/const" errors.
-    assign tx_ready_passthru = tx0_umi_ready;
 
     always @(posedge clk) begin
         if (write) begin


### PR DESCRIPTION
A few small changes I had to make to get the `umi_mem` example to run through the compile step:

* Update the UMI signal names
* Add a wire between `.umi_in_ready` and the corresponding module input, because Verilator threw an "Assigning to input/const variable" error.

I'm still seeing an issue where the switchboard `umidriver` app is timing out, but I don't think that's related to the Verilog.