### PR TITLE
Clean up WIDTH errors seen in Verilator when compiling ebrick-fpga

### DIFF
--- a/umi/rtl/umi_decode.v
+++ b/umi/rtl/umi_decode.v
@@ -76,7 +76,7 @@ module umi_decode #(parameter CW = 32)
    assign cmd_user1_resp   = (command[3:0]==UMI_RESP_USER1[3:0]);
    assign cmd_future0_resp = (command[3:0]==UMI_RESP_FUTURE0[3:0]);
    assign cmd_future1_resp = (command[3:0]==UMI_RESP_FUTURE1[3:0]);
-   assign cmd_link_resp    = (command[3:0]==UMI_RESP_LINK[7:0]);
+   assign cmd_link_resp    = (command[7:0]==UMI_RESP_LINK[7:0]);
 
    // read modify writes
    assign cmd_atomic_add  = cmd_atomic & (command[15:8]==UMI_REQ_ATOMICADD);

--- a/umi/rtl/umi_pack.v
+++ b/umi/rtl/umi_pack.v
@@ -36,7 +36,7 @@ module umi_pack #(parameter CW = 32)
    wire        cmd_atomic;
    wire        extended_user_sel;
 
-   assign extended_user_sel = cmd_link | cmd_link_resp | cmd_err;
+   assign extended_user_sel = cmd_link | cmd_link_resp | cmd_error;
 
    // Take only the required fields for the decode
    assign cmd_in[31:0] = {24'h00_0000,cmd_size[2:0],cmd_opcode[4:0]};


### PR DESCRIPTION
Primary change is hooking up cmd_error instead of cmd_err, which looked at first glance like a real bug.