### PR TITLE
fix umi_mux not to assert ready for invalid request

### DIFF
--- a/umi/rtl/umi_mux.v
+++ b/umi/rtl/umi_mux.v
@@ -36,7 +36,7 @@ module umi_mux
 
    // TODO - check if it does not creates a timing loop.
    // ready pusback
-   assign umi_in_ready[N-1:0] = ~umi_in_valid[N-1:0] |
+   assign umi_in_ready[N-1:0] = //~umi_in_valid[N-1:0] |
 				(umi_in_valid[N-1:0] & {N{umi_out_ready}});
 
    // packet mux


### PR DESCRIPTION
Fixed a small bug in umi_mux (not really a hard bug but not as expected).
When one of the inputs does not have a valid request there is no need to assert ready for it. It is not a violation of the spec but doing so hides bugs where the host is depending on ready to assert valid.

Specifically in the mux module the expectation is that ready out will be one-hot and this bug violates it. This is why the fix is needed.