### PR TITLE
fix bug - ready_in should not be asserted during reset

### DIFF
--- a/umi/rtl/umi_fifo.v
+++ b/umi/rtl/umi_fifo.v
@@ -52,19 +52,25 @@ module umi_fifo
    wire             fifo_write;
    wire [DW+AW+AW+CW-1:0] fifo_dout;
    wire 	    fifo_in_ready;
+   wire             sync_nreset;
 
    //#################################
    // UMI Control Logic
    //#################################
 
+   // CHIPS-399 block fifo input and ready during reset
+   la_rsync la_rsync_i (.clk(umi_in_clk),
+                        .nrst_in (umi_in_nreset),
+                        .nrst_out (sync_nreset));
+
    // Read FIFO when ready (blocked inside fifo when empty)
    assign fifo_read = ~fifo_empty & umi_out_ready;
 
    // Write fifo when high (blocked inside fifo when full)
-   assign fifo_write = ~fifo_full & umi_in_valid ;
+   assign fifo_write = ~fifo_full & umi_in_valid & sync_nreset;
 
    // FIFO pushback
-   assign fifo_in_ready = ~fifo_full;
+   assign fifo_in_ready = ~fifo_full & sync_nreset;
 
    //#################################
    // Standard Dual Clock FIFO


### PR DESCRIPTION
Added reset sync and blocked write+ready_in during reset.