### PR TITLE
umi_unpack: drive cmd_len=0 for UMI_REQ_ATOMIC

### DIFF
--- a/umi/rtl/umi_unpack.v
+++ b/umi/rtl/umi_unpack.v
@@ -56,6 +56,7 @@ module umi_unpack
     .cmd_error      (cmd_error[]),
     .cmd_request    (cmd_request[]),
     .cmd_response   (cmd_response[]),
+    .cmd_atomic     (cmd_atomic[]),
     .cmd_link\(.*\) (cmd_link\1[]),
     .command        (packet_cmd[]),
     .cmd_.*         (),


### PR DESCRIPTION
This small PR changes `umi_unpack` to drive `cmd_len`=0 when processing `UMI_REQ_ATOMIC`.  This fixes an issue I observed in `umi_fifo_flex`, where atomic transactions were sometimes being split.  The problem arises because an atomic request does not have the `LEN` field, and reuses that space for `ATYPE`.  In `umi_fifo_flex`, `cmd_len` is used directly from `umi_unpack` to determine the number of words in a packet, so it may look like an atomic packet contains multiple words.

We could fix this directly in `umi_fifo_flex`, but I am proposing making this change in `umi_unpack` to help prevent similar bugs in the future.