### PR TITLE
Allow waiving group ID check in umi_regif

### DIFF
--- a/umi/rtl/umi_regif.v
+++ b/umi/rtl/umi_regif.v
@@ -9,6 +9,11 @@
  * Read data is returned as UMI response packets. Reads requests can occur
  * at a maximum rate of one transaction every two cycles.
  *
+ * This module can also check if the incoming access is within the designated
+ * address range by setting the GRPOFFSET, GRPAW, and GRPID parameter.
+ * The address range [GRPOFFSET+:GRPAW] is checked against GRPID for a match.
+ * To disable the check, set the GRPAW to 0.
+ *
  * Only read/writes <= DW is supported.
  *
  ******************************************************************************/


### PR DESCRIPTION
When group ID checking is unnecessary or undesired, with this PR it's now possible to bypass the check by setting GRPAW parameter to 0.