### PR TITLE
umi_endpoint backpressure bug

### DIFF
--- a/umi/rtl/umi_endpoint.v
+++ b/umi/rtl/umi_endpoint.v
@@ -178,8 +178,8 @@ module umi_endpoint
               .command          (udev_req_cmd[CW-1:0])); // Templated
 
    // TODO - implement atomic
-   assign loc_read  = ready_gated & cmd_read & udev_req_valid & udev_req_ready;
-   assign loc_write = ready_gated & (cmd_write | cmd_write_posted) & udev_req_valid & udev_req_ready;
+   assign loc_read  = ready_gated & cmd_read & udev_req_valid & ~request_stall;
+   assign loc_write = ready_gated & (cmd_write | cmd_write_posted) & udev_req_valid & ~request_stall;
    assign loc_resp  = ready_gated & (cmd_read | cmd_write) & udev_req_valid & loc_ready;
 
    //############################


### PR DESCRIPTION
This PR updates the `umi_endpoint` module so that the `loc_read` and `loc_write` signals will only assert if both `udev_req_valid` is asserted and `request_stall` is deasserted.

Previously `loc_read/write` could assert even if `udev_req_ready` was deasserted due to `request_stall` being asserted, which caused some issues where logic downstream of the endpoint in the FPGA chiplet bitstream controller processed false requests from the host, which was asserting valid for a few clock cycles while waiting for the ready signal from the endpoint assert.