### PR TITLE
Lumi sb cdc

### DIFF
--- a/lumi/rtl/lumi.v
+++ b/lumi/rtl/lumi.v
@@ -13,7 +13,7 @@
  * 1. convert from CLINK
  *
  *****************************************************************************/
-module lumi_async
+module lumi
   #(parameter TARGET = "DEFAULT", // compiler target
     parameter IDOFFSET = 24,      // chip ID address offset
     parameter GRPOFFSET = 24,     // group address offset


### PR DESCRIPTION
split side band bus to two clocks (like in main data path) to remove the need for async fifo at the top level.