### PR TITLE
Lumi auto mode

### DIFF
--- a/lumi/rtl/lumi.v
+++ b/lumi/rtl/lumi.v
@@ -17,6 +17,8 @@
  *
  * Documentation:
  * - Link UMI ("LUMI") Top Level Module
+ * - Wakes up in 1B, infinite credit mode. Chaging width must be done before
+ *   enabling credit mechanism or sending traffic
  *
  ******************************************************************************/
 
@@ -26,6 +28,7 @@ module lumi
     parameter GRPOFFSET = 24,     // group address offset
     parameter GRPAW = 8,          // group address width
     parameter GRPID = 0,          // group ID
+    parameter INITIOW = 0,        // Default interface width (in power of 2 bytes)
     // for development
     parameter DW = 128,           // umi packet width
     parameter CW = 32,            // umi packet width
@@ -177,7 +180,9 @@ module lumi
                .DW(DW),
                .CW(CW),
                .AW(AW),
-               .RXFIFOW(RXFIFOW))
+               .RXFIFOW(RXFIFOW),
+               .INITIOW(INITIOW)
+               )
    lumi_regs(/*AUTOINST*/
              // Outputs
              .udev_req_ready    (cb2regs_ready),         // Templated

--- a/lumi/rtl/lumi_regs.v
+++ b/lumi/rtl/lumi_regs.v
@@ -25,6 +25,7 @@ module lumi_regs
     parameter GRPOFFSET = 24,     // group address offset
     parameter GRPAW = 8,          // group address width
     parameter GRPID = 0,          // group ID
+    parameter INITIOW = ,         // Default interface width (in power of 2 bytes)
     // for development only (fixed )
     parameter CW = 32,            // umi data width
     parameter AW = 64,            // address width
@@ -153,7 +154,7 @@ module lumi_regs
    // the link parameters first.
    always @ (posedge clk or negedge nreset)
      if(!nreset)
-       txmode_reg[RW-1:0] <= 'b0;
+       txmode_reg[RW-1:0] <= {{(RW-24){1'b0}},INITIOW[7:0],15'h0000,1'b1};
      else if(write_txmode)
        txmode_reg[RW-1:0] <= reg_wrdata[RW-1:0];
 
@@ -174,7 +175,7 @@ module lumi_regs
 
    always @ (posedge clk or negedge nreset)
      if(!nreset)
-       rxmode_reg[RW-1:0] <= 'b0;
+       rxmode_reg[RW-1:0] <= {{(RW-24){1'b0}},INITIOW[7:0],15'h0000,1'b1};
      else if(write_rxmode)
        rxmode_reg[RW-1:0] <= reg_wrdata[RW-1:0];
 

--- a/lumi/rtl/lumi_regs.v
+++ b/lumi/rtl/lumi_regs.v
@@ -25,7 +25,7 @@ module lumi_regs
     parameter GRPOFFSET = 24,     // group address offset
     parameter GRPAW = 8,          // group address width
     parameter GRPID = 0,          // group ID
-    parameter INITIOW = ,         // Default interface width (in power of 2 bytes)
+    parameter INITIOW = 0,        // Default interface width (in power of 2 bytes)
     // for development only (fixed )
     parameter CW = 32,            // umi data width
     parameter AW = 64,            // address width


### PR DESCRIPTION
This change allows lumi to be used without configuration.
- Rx enable and Tx enable are high by default
- Rx width and Tx width reset value from a parameter 

The parameter is used in cases (like ucie) where a specific instance of lumi needs to wake up in a wide configuration. In ebrick it will be 0 (8b).
If width is changed by configuration (like in ebrick 3d mode) it should be set before enabling the credit mechanism or sending any traffic. 