### PR TITLE
disable credit init state when crdt_en is zero

### DIFF
--- a/lumi/rtl/lumi.v
+++ b/lumi/rtl/lumi.v
@@ -386,6 +386,7 @@ module lumi
    //########################
 
    /*lumi_rx  AUTO_TEMPLATE (
+    .csr_crdt_en         (csr_txcrdt_en[]),
     .csr_rx\(.*\)        (csr_rx\1),
     .csr_\(.*\)          (csr_@"(substring vl-cell-name 5 7)"\1[]),
     .io\(.*\)            (@"(substring vl-cell-name 5 7)"\1[]),
@@ -427,6 +428,7 @@ module lumi
            .clk                 (clk),
            .nreset              (nreset),
            .csr_en              (csr_rxen),              // Templated
+           .csr_crdt_en         (csr_txcrdt_en),         // Templated
            .csr_iowidth         (csr_rxiowidth[7:0]),    // Templated
            .vss                 (vss),
            .vdd                 (vdd),

--- a/lumi/rtl/lumi_rx.v
+++ b/lumi/rtl/lumi_rx.v
@@ -37,6 +37,7 @@ module lumi_rx
     input             clk,                // clock for sampling input data
     input             nreset,             // async active low reset
     input             csr_en,             // 1=enable outputs
+    input             csr_crdt_en,        // 1=enable credits
     input [7:0]       csr_iowidth,        // pad bus width
     input             vss,                // common ground
     input             vdd,                // core supply
@@ -744,6 +745,11 @@ module lumi_rx
        begin
           loc_crdt_init[1:0] <= 2'b11;
           rmt_crdt_init[1:0] <= 2'b11;
+       end
+     else if (csr_en & ~csr_crdt_en)
+       begin
+          loc_crdt_init[1:0] <= 2'b00;
+          rmt_crdt_init[1:0] <= 2'b00;
        end
      else
        begin


### PR DESCRIPTION
Small fix to infinite credit mode following the credit init state handshake. 
When credit mechanism is disabled should not wait for credit init. 