### PR TITLE
Add mode to umi_ram

### DIFF
--- a/umi/umi/rtl/umi_ram.v
+++ b/umi/umi/rtl/umi_ram.v
@@ -34,6 +34,7 @@ module umi_ram
     input               clk,    // clock signals
     input               nreset, // async active low reset
     input  [CTRLW-1:0]  sram_ctrl, // Control signal for SRAM
+    input  [1:0]        mode,   // [00]=priority,[10]=roundrobin,[x1]=reserved
     // Device port
     input  [N-1:0]      udev_req_valid,
     input  [N*CW-1:0]   udev_req_cmd,
@@ -74,7 +75,6 @@ module umi_ram
    //##################################################################
 
    /*umi_arbiter AUTO_TEMPLATE(
-    .mode     (2'b10),
     .mask     ({@"vl-width"{1'b0}}),
     .requests (udev_req_valid[]),
     .grants   (umi_req_grants[]),
@@ -87,7 +87,7 @@ module umi_ram
                 // Inputs
                 .clk            (clk),
                 .nreset         (nreset),
-                .mode           (2'b10),                 // Templated
+                .mode           (mode),                  // Templated
                 .mask           ({N{1'b0}}),             // Templated
                 .requests       (udev_req_valid[N-1:0])); // Templated
 

--- a/umi/umi/testbench/testbench_umi_ram.sv
+++ b/umi/umi/testbench/testbench_umi_ram.sv
@@ -51,6 +51,7 @@ module testbench (
    wire [N-1:0]         udev_resp_ready;
 
    wire [CTRLW-1:0]  sram_ctrl = 8'b0;
+   wire [1:0]        mode = 2'b10;
 
    ///////////////////////////////////////////
    // Host side umi agents
@@ -105,6 +106,7 @@ module testbench (
              // Inputs
              .clk                 (clk),
              .nreset              (nreset),
+             .mode                (mode),
              .sram_ctrl           (sram_ctrl[CTRLW-1:0]),
              .udev_req_valid      (udev_req_valid[N-1:0]),
              .udev_req_cmd        (udev_req_cmd[N*CW-1:0]),


### PR DESCRIPTION
This PR exposes the mode bits of the arbiter inside umi_ram to the top level. This allows the user to set different arbitration modes during instantiation depending on the behavior they expect from the memory.