### PR TITLE
Revert "Updated instances of la_syncfifo to have a clear input"

### DIFF
--- a/umi/lumi/rtl/lumi_rx.v
+++ b/umi/lumi/rtl/lumi_rx.v
@@ -558,7 +558,6 @@ module lumi_rx
                    // Inputs
                    .clk              (ioclk),
                    .nreset           (ionreset),
-                   .clear            (1'b0),
                    .vss              (1'b0),
                    .vdd              (1'b1),
                    .chaosmode        (1'b0),
@@ -606,7 +605,6 @@ module lumi_rx
                     // Inputs
                     .clk              (ioclk),
                     .nreset           (ionreset),
-                    .clear            (1'b0),
                     .vss              (1'b0),
                     .vdd              (1'b1),
                     .chaosmode        (1'b0),

--- a/umi/umi/rtl/umi_fifo_flex.v
+++ b/umi/umi/rtl/umi_fifo_flex.v
@@ -607,7 +607,6 @@ module umi_fifo_flex
                // Inputs
                .clk          (umi_in_clk),
                .nreset       (umi_in_nreset),
-               .clear        (1'b0),
                .wr_din       (fifo_din[ODW+AW+AW+CW-1:0]),
                .wr_en        (fifo_write),
                .chaosmode    (chaosmode),

--- a/umi/utils/rtl/tl2umi_np.v
+++ b/umi/utils/rtl/tl2umi_np.v
@@ -472,7 +472,6 @@ module tl2umi_np #(
     ) tl2umi_req_fifo (
         .clk        (clk),
         .nreset     (nreset),
-        .clear      (1'b0),
 
         .vss        (1'b0),
         .vdd        (1'b1),


### PR DESCRIPTION
This reverts commit d68dc8a384d01b0180655221718ad1007d847828.

We can undo-undo this once lambdalib has been updated.