### PR TITLE
Fix pstrb signal name

### DIFF
--- a/umi/utils/rtl/umi2apb.v
+++ b/umi/utils/rtl/umi2apb.v
@@ -69,7 +69,7 @@ module umi2apb #(
     output reg              penable,    // enable
     output                  pwrite,     // 0=read, 1=write
     output     [RW-1:0]     pwdata,     // write data
-    output     [(RW/8)-1:0] pwstrb,     // strobe
+    output     [(RW/8)-1:0] pstrb,      // strobe
     input                   pready,     // ready
     input      [RW-1:0]     prdata,     // read data
     input                   pslverr     // err
@@ -229,7 +229,7 @@ module umi2apb #(
     assign pprot      = {1'b0, req_prot};
     assign pwrite     = cmd_write | cmd_write_posted;
     assign pwdata     = incoming_req ? udev_req_data[RW-1:0] : udev_req_data_r[RW-1:0];
-    assign pwstrb     = {(RW/8){1'b1}}; // TODO: Support strobe
+    assign pstrb      = {(RW/8){1'b1}}; // TODO: Support strobe
     assign psel       = incoming_req | penable;
 
     always @(posedge clk or negedge nreset)

--- a/umi/utils/testbench/test_tl2umi_np.py
+++ b/umi/utils/testbench/test_tl2umi_np.py
@@ -11,7 +11,6 @@ def build():
     chip.use(umi)
     chip.use(dvflow, tool='icarus')
 
-    chip.set('option', 'mode', 'sim')
     chip.set('option', 'flow', 'dvflow')
 
     chip.input('utils/testbench/tb_tl2umi_np.v', package='umi')

--- a/umi/utils/testbench/testbench_umi2apb.sv
+++ b/umi/utils/testbench/testbench_umi2apb.sv
@@ -68,7 +68,7 @@ module testbench (
     wire                penable;
     wire                pwrite;
     wire [RW-1:0]       pwdata;
-    wire [(RW/8)-1:0]   pwstrb;
+    wire [(RW/8)-1:0]   pstrb;
     wire                pready;
     wire [RW-1:0]       prdata;
     wire                pslverr;
@@ -104,7 +104,7 @@ module testbench (
         .penable            (penable),
         .pwrite             (pwrite),
         .pwdata             (pwdata),
-        .pwstrb             (pwstrb),
+        .pstrb              (pstrb),
         .pready             (pready),
         .prdata             (prdata),
         .pslverr            (pslverr));


### PR DESCRIPTION
According to the APB spec, the signal should be named as PSTRB rather than PWSTRB