### PR TITLE
Adding umi_port and N x M umi_switch

### DIFF
--- a/umi/sumi/rtl/umi_port.v
+++ b/umi/sumi/rtl/umi_port.v
@@ -31,7 +31,7 @@ module umi_port
     input [1:0]       arbmode, // arbiter` mode (0=fixed)
     input [N-1:0]     arbmask, // arbiter mask (0=fixed)
     // incoming UMI
-    input [N-1:0]     umi_in_request,
+    input [N-1:0]     umi_in_valid,
     input [N*CW-1:0]  umi_in_cmd,
     input [N*AW-1:0]  umi_in_dstaddr,
     input [N*AW-1:0]  umi_in_srcaddr,
@@ -49,7 +49,7 @@ module umi_port
    wire [N*N-1:0]    grants;
 
    //##############################
-   // Request Arbiter
+   // Valid Arbiter
    //##############################
 
    umi_arbiter #(.N(N))
@@ -60,7 +60,7 @@ module umi_port
                 .nreset   (nreset),
                 .mode     (arbmode[1:0]),
                 .mask     (arbmask[N-1:0]),
-                .requests (umi_in_request[N-1:0]));
+                .requests (umi_in_valid[N-1:0]));
 
    assign umi_out_valid = |grants[N-1:0];
 
@@ -69,7 +69,7 @@ module umi_port
    //##############################
 
 
-   // request[j] | out_ready[j] | grant[j] | in_ready
+   // valid[j] | out_ready[j] | grant[j] | in_ready
    //------------------------------------------------
    //     0             x           x      | 1
    //     1             0           x      | 0
@@ -81,7 +81,7 @@ module umi_port
      begin
         umi_in_ready[N-1:0] = {N{1'b1}};
         for (j=0;j<N;j=j+1)
-          umi_in_ready[j] = umi_in_ready[j] & ~(umi_in_request[j] &
+          umi_in_ready[j] = umi_in_ready[j] & ~(umi_in_valid[j] &
                                                 (~grants[j] | ~umi_out_ready));
      end
 

--- a/umi/sumi/rtl/umi_port.v
+++ b/umi/sumi/rtl/umi_port.v
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright 2024 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * N:1 UMI transaction mux with arbiter and flow control.
+ *
+ ******************************************************************************/
+
+module umi_port
+  #(parameter N  = 2,   // mumber of inputs
+    parameter DW = 128, // umi data width
+    parameter CW = 32,  // umi command width
+    parameter AW = 6   // umi address width
+    )
+   (// controls
+    input             clk,
+    input             nreset,
+    input [1:0]       arbmode, // arbiter` mode (0=fixed)
+    input [N-1:0]     arbmask, // arbiter mask (0=fixed)
+    // incoming UMI
+    input [N-1:0]     umi_in_request,
+    input [N*CW-1:0]  umi_in_cmd,
+    input [N*AW-1:0]  umi_in_dstaddr,
+    input [N*AW-1:0]  umi_in_srcaddr,
+    input [N*DW-1:0]  umi_in_data,
+    output reg [N-1:0] umi_in_ready,
+    // outgoing UMI
+    output            umi_out_valid,
+    output [CW-1:0]   umi_out_cmd,
+    output [AW-1:0]   umi_out_dstaddr,
+    output [AW-1:0]   umi_out_srcaddr,
+    output [DW-1:0]   umi_out_data,
+    input             umi_out_ready
+    );
+
+   wire [N*N-1:0]    grants;
+
+   //##############################
+   // Request Arbiter
+   //##############################
+
+   umi_arbiter #(.N(N))
+   umi_arbiter (// Outputs
+                .grants   (grants[N-1:0]),
+                // Inputs
+                .clk      (clk),
+                .nreset   (nreset),
+                .mode     (arbmode[1:0]),
+                .mask     (arbmask[N-1:0]),
+                .requests (umi_in_request[N-1:0]));
+
+   assign umi_out_valid = |grants[N-1:0];
+
+   //##############################
+   // Ready
+   //##############################
+
+
+   // request[j] | out_ready[j] | grant[j] | in_ready
+   //------------------------------------------------
+   //     0             x           x      | 1
+   //     1             0           x      | 0
+   //     1             1           0      | 0
+   //     1             1           1      | 1
+
+   integer j;
+   always @(*)
+     begin
+        umi_in_ready[N-1:0] = {N{1'b1}};
+        for (j=0;j<N;j=j+1)
+          umi_in_ready[j] = umi_in_ready[j] & ~(umi_in_request[j] &
+                                                (~grants[j] | ~umi_out_ready));
+     end
+
+   //##############################
+   // Output Mux
+   //##############################
+
+   // data
+   la_vmux #(.N(N),
+             .W(DW))
+   la_data_vmux(// Outputs
+                .out (umi_out_data[DW-1:0]),
+                // Inputs
+                .sel (grants[N-1:0]),
+                .in  (umi_in_data[N*DW-1:0]));
+
+   // srcaddr
+   la_vmux #(.N(N),
+             .W(AW))
+   la_src_vmux(// Outputs
+               .out (umi_out_srcaddr[AW-1:0]),
+               // Inputs
+               .sel (grants[N-1:0]),
+               .in  (umi_in_srcaddr[N*AW-1:0]));
+
+   // dstaddr
+   la_vmux #(.N(N),
+             .W(AW))
+   la_dst_vmux(// Outputs
+               .out (umi_out_dstaddr[AW-1:0]),
+               // Inputs
+               .sel (grants[N-1:0]),
+               .in  (umi_in_dstaddr[N*AW-1:0]));
+
+   // command
+   la_vmux #(.N(N),
+             .W(CW))
+   la_cmd_vmux(// Outputs
+               .out (umi_out_cmd[CW-1:0]),
+               // Inputs
+               .sel (grants[N-1:0]),
+               .in  (umi_in_cmd[N*CW-1:0]));
+
+endmodule

--- a/umi/sumi/rtl/umi_switch.v
+++ b/umi/sumi/rtl/umi_switch.v
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright 2024 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Pipelined non-blocking swith with M outputs and N inputs
+ *
+ * - The order and masking is as follows
+ *
+ * [0]     = input 0   requesting output 0
+ * [1]     = input 1   requesting output 0
+ * [2]     = input 2   requesting output 0
+ * [N-1]   = input N-1 requesting output 0
+ * [N]     = input 0   requesting output 1
+ * [N+1]   = input 1   requesting output 1
+ * [N+2]   = input 2   requesting output 1
+ * [2*N-1] = input N-1 requesting output 1
+ *
+ *
+ ******************************************************************************/
+
+module umi_switch
+  #(parameter DW = 256, // umi data width
+    parameter CW = 32,  // umi command width
+    parameter AW = 64,  // umi adress width
+    parameter N = 3,    // number of input ports
+    parameter M = 6     // number of outputs ports
+    )
+   (// controls
+    input              clk,
+    input              nreset,
+    input [1:0]        arbmode, // arbiter mode (0=fixed)
+    input [N*M-1:0]    arbmask, // (1=mask/disable path)
+    // Incoming UMI
+    input [N*M-1:0]    umi_in_request,
+    input [N*CW-1:0]   umi_in_cmd,
+    input [N*AW-1:0]   umi_in_dstaddr,
+    input [N*AW-1:0]   umi_in_srcaddr,
+    input [N*DW-1:0]   umi_in_data,
+    output reg [N-1:0] umi_in_ready,
+    // Outgoing UMI
+    output [M-1:0]     umi_out_valid,
+    output [M*CW-1:0]  umi_out_cmd,
+    output [M*AW-1:0]  umi_out_dstaddr,
+    output [M*AW-1:0]  umi_out_srcaddr,
+    output [M*DW-1:0]  umi_out_data,
+    input [M-1:0]      umi_out_ready
+    );
+
+   genvar i;
+
+   wire [M*N-1:0] umi_ready;
+
+   //#######################################################
+   // Output Ports
+   //#######################################################
+
+   // data broadcasted to all output ports for M inputs
+   // N individual requests sent to each port
+   // M*N ready signals generated
+
+   for (i=0;i<M;i=i+1)
+     begin
+        umi_port #(.N(N),
+                   .DW(DW),
+                   .CW(CW),
+                   .AW(AW))
+        out (// Outputs
+             .umi_in_ready          (umi_ready[i*N+:N]),
+             .umi_out_valid         (umi_out_valid[i]),
+             .umi_out_cmd           (umi_out_cmd[i*CW+:CW]),
+             .umi_out_dstaddr       (umi_out_dstaddr[i*AW+:AW]),
+             .umi_out_srcaddr       (umi_out_srcaddr[i*AW+:AW]),
+             .umi_out_data          (umi_out_data[i*DW+:DW]),
+             // Inputs
+             .clk                   (clk),
+             .nreset                (nreset),
+             .arbmode               (arbmode[1:0]),
+             .arbmask               (arbmask[i*N+:N]),
+             .umi_in_request        (umi_in_request[i*N+:N]),
+             .umi_in_cmd            (umi_in_cmd[N*CW-1:0]),
+             .umi_in_dstaddr        (umi_in_dstaddr[N*AW-1:0]),
+             .umi_in_srcaddr        (umi_in_srcaddr[N*AW-1:0]),
+             .umi_in_data           (umi_in_data[N*DW-1:0]),
+             .umi_out_ready         (umi_out_ready[i]));
+     end
+
+   //#########################################
+   // Merge ready signals from all ports
+   //##########################################
+
+   integer j,k;
+   always @(*)
+     begin
+        umi_in_ready[N-1:0] = {N{1'b1}};
+        for (j=0;j<N;j=j+1)
+          for (k=0;k<M;k=k+1)
+            umi_in_ready[j] = umi_in_ready[j] & umi_ready[j+N*k];
+     end
+
+endmodule

--- a/umi/sumi/rtl/umi_switch.v
+++ b/umi/sumi/rtl/umi_switch.v
@@ -46,7 +46,7 @@ module umi_switch
     input [1:0]        arbmode, // arbiter mode (0=fixed)
     input [N*M-1:0]    arbmask, // (1=mask/disable path)
     // Incoming UMI
-    input [N*M-1:0]    umi_in_request,
+    input [N*M-1:0]    umi_in_valid,
     input [N*CW-1:0]   umi_in_cmd,
     input [N*AW-1:0]   umi_in_dstaddr,
     input [N*AW-1:0]   umi_in_srcaddr,
@@ -70,7 +70,7 @@ module umi_switch
    //#######################################################
 
    // data broadcasted to all output ports for M inputs
-   // N individual requests sent to each port
+   // N individual valids sent to each port
    // M*N ready signals generated
 
    for (i=0;i<M;i=i+1)
@@ -91,7 +91,7 @@ module umi_switch
              .nreset                (nreset),
              .arbmode               (arbmode[1:0]),
              .arbmask               (arbmask[i*N+:N]),
-             .umi_in_request        (umi_in_request[i*N+:N]),
+             .umi_in_valid          (umi_in_valid[i*N+:N]),
              .umi_in_cmd            (umi_in_cmd[N*CW-1:0]),
              .umi_in_dstaddr        (umi_in_dstaddr[N*AW-1:0]),
              .umi_in_srcaddr        (umi_in_srcaddr[N*AW-1:0]),


### PR DESCRIPTION
- The current crossbar is awkward, an N:1 output mux with an arbiter and ready pushback is easier to use in some cases where we don't have a full N x N crossbar.
- Using new umi_port to create an N input by M output switch