### PR TITLE
Cleanup for icarus

### DIFF
--- a/umi/sumi/rtl/umi_mem_agent.v
+++ b/umi/sumi/rtl/umi_mem_agent.v
@@ -222,7 +222,7 @@ module umi_mem_agent
      end
    end
 
-   assign mem_rddata_atomic = mem_rddata<<postatomic_shift;
+   assign mem_rddata_atomic = (mem_rddata & wmask_r)<<postatomic_shift;
 
    always @(*) begin
      if (loc_atype_r == 8'h00)

--- a/umi/sumi/testbench/testbench_crossbar.sv
+++ b/umi/sumi/testbench/testbench_crossbar.sv
@@ -27,12 +27,25 @@ module testbench
     parameter AW=64,
     parameter CW=32)
    (
+`ifdef VERILATOR
     input clk
-    );
+`endif
+);
 
 `include "switchboard.vh"
 
    localparam N = PORTS;
+
+   localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
 
    /*AUTOWIRE*/
    reg               nreset;

--- a/umi/sumi/testbench/testbench_fifo.sv
+++ b/umi/sumi/testbench/testbench_fifo.sv
@@ -23,14 +23,27 @@
 `default_nettype none
 
 module testbench (
-                  input clk
-                  );
+`ifdef VERILATOR
+    input clk
+`endif
+);
 
    parameter integer DW=128;
    parameter integer AW=64;
    parameter integer CW=32;
    parameter integer CTRLW=8;
    parameter integer DEPTH=1;
+
+   localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
 
    /*AUTOWIRE*/
    // Beginning of automatic wires (for undeclared instantiated-module outputs)

--- a/umi/sumi/testbench/testbench_fifo_flex.sv
+++ b/umi/sumi/testbench/testbench_fifo_flex.sv
@@ -24,8 +24,10 @@
 `default_nettype none
 
 module testbench (
-                  input clk
-                  );
+`ifdef VERILATOR
+    input clk
+`endif
+);
 
    parameter integer IDW=128;
    parameter integer ODW=32;
@@ -34,6 +36,17 @@ module testbench (
    parameter integer CTRLW=8;
    parameter integer DEPTH=512;
    parameter integer ASYNC=0;
+
+   localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
 
    `ifndef SPLIT
      `define SPLIT 0

--- a/umi/sumi/testbench/testbench_isolate.sv
+++ b/umi/sumi/testbench/testbench_isolate.sv
@@ -23,7 +23,9 @@
 `default_nettype none
 
 module testbench (
+`ifdef VERILATOR
     input clk
+`endif
 );
 
 `include "switchboard.vh"
@@ -33,7 +35,17 @@ module testbench (
     parameter integer DW    = 256;
     parameter integer ISO   = 1;
 
+    localparam PERIOD_CLK   = 10;
     localparam RST_CYCLES   = 16;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
 
     // Reset control
     reg [RST_CYCLES-1:0]    nreset_vec;

--- a/umi/sumi/testbench/testbench_mem_agent.sv
+++ b/umi/sumi/testbench/testbench_mem_agent.sv
@@ -23,8 +23,10 @@
 `default_nettype none
 
 module testbench (
-                  input clk
-                  );
+`ifdef VERILATOR
+    input clk
+`endif
+);
 
    parameter integer RW=32;
    parameter integer DW=256;
@@ -33,6 +35,16 @@ module testbench (
    parameter integer CTRLW=8;
    parameter integer RAMDEPTH=512;
 
+   localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
 
    /*AUTOWIRE*/
    reg                  nreset;

--- a/umi/sumi/tests/conftest.py
+++ b/umi/sumi/tests/conftest.py
@@ -41,7 +41,7 @@ def build_dir(pytestconfig):
 
 @pytest.fixture
 def sumi_dut(build_dir, request):
-    dut = SbDut('testbench', default_main=True, trace=True)
+    dut = SbDut('testbench', default_main=True, trace=False)
 
     dut.use(sumi)
 


### PR DESCRIPTION
Some clock changes to make the tests works with icarus as well.
Disabled tracing by default.
Additionally, a bug fix for umi_mem_agent that was caught in icarus.