### PR TITLE
More tests for sumi

### DIFF
--- a/umi/sumi/rtl/umi_mux.v
+++ b/umi/sumi/rtl/umi_mux.v
@@ -28,8 +28,8 @@ module umi_mux
    (// controls
     input             clk,
     input             nreset,
-    input [1:0]       arbmode, // arbiter` mode (0=fixed)
-    input [N-1:0]     arbmask, // arbiter mask (0=fixed)
+    input [1:0]       arbmode, // arbiter mode (0=fixed)
+    input [N-1:0]     arbmask, // arbiter mask (1=input is masked)
     // incoming UMI
     input [N-1:0]     umi_in_valid,
     input [N*CW-1:0]  umi_in_cmd,

--- a/umi/sumi/testbench/testbench_demux.sv
+++ b/umi/sumi/testbench/testbench_demux.sv
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright 2024 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ * - Simple umi demux testbench
+ *
+ ******************************************************************************/
+
+module testbench (
+`ifdef VERILATOR
+    input clk
+`endif
+);
+
+`include "switchboard.vh"
+
+    localparam M  = 4;
+    localparam DW = 256;
+    localparam CW = 32;
+    localparam AW = 64;
+
+    localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
+
+    // Initialize UMI
+    integer valid_mode, ready_mode;
+
+    initial begin
+        /* verilator lint_off IGNOREDRETURN */
+        if (!$value$plusargs("valid_mode=%d", valid_mode)) begin
+            valid_mode = 2;  // default if not provided as a plusarg
+        end
+
+        if (!$value$plusargs("ready_mode=%d", ready_mode)) begin
+            ready_mode = 2;  // default if not provided as a plusarg
+        end
+        /* verilator lint_on IGNOREDRETURN */
+    end
+
+    wire [M-1:0]    select;
+
+    wire            umi_in_valid;
+    wire [CW-1:0]   umi_in_cmd;
+    wire [AW-1:0]   umi_in_dstaddr;
+    wire [AW-1:0]   umi_in_srcaddr;
+    wire [DW-1:0]   umi_in_data;
+    wire            umi_in_ready;
+
+    wire [M-1:0]    umi_out_valid;
+    wire [M*CW-1:0] umi_out_cmd;
+    wire [M*AW-1:0] umi_out_dstaddr;
+    wire [M*AW-1:0] umi_out_srcaddr;
+    wire [M*DW-1:0] umi_out_data;
+    wire [M-1:0]    umi_out_ready;
+
+    ///////////////////////////////////////////
+    // Host side umi agents
+    ///////////////////////////////////////////
+
+    genvar          i;
+
+    umi_rx_sim #(
+        .VALID_MODE_DEFAULT (2),
+        .DW                 (DW)
+    ) umi_rx_i (
+        .clk        (clk),
+
+        .valid      (umi_in_valid),
+        .cmd        (umi_in_cmd),
+        .dstaddr    (umi_in_dstaddr),
+        .srcaddr    (umi_in_srcaddr),
+        .data       (umi_in_data),
+        .ready      (umi_in_ready)
+    );
+
+    assign select = umi_in_dstaddr[40+:M];
+
+    initial begin
+        `ifndef VERILATOR
+            #1;
+        `endif
+        umi_rx_i.init("client2rtl_0.q");
+        umi_rx_i.set_valid_mode(valid_mode);
+    end
+
+    generate
+    for(i = 0; i < M; i = i + 1) begin: demux_out
+        umi_tx_sim #(
+            .READY_MODE_DEFAULT (2),
+            .DW                 (DW)
+        ) umi_tx_i (
+            .clk        (clk),
+
+            .valid      (umi_out_valid[i]),
+            .cmd        (umi_out_cmd[i*CW+:CW]),
+            .dstaddr    (umi_out_dstaddr[i*AW+:AW]),
+            .srcaddr    (umi_out_srcaddr[i*AW+:AW]),
+            .data       (umi_out_data[i*DW+:DW]),
+            .ready      (umi_out_ready[i])
+        );
+
+        initial begin
+            demux_out[i].umi_tx_i.init($sformatf("rtl2client_%0d.q", i));
+            demux_out[i].umi_tx_i.set_ready_mode(ready_mode);
+        end
+    end
+    endgenerate
+
+    // UMI Demux
+    umi_demux #(
+        .M  (M),
+        .DW (DW),
+        .CW (CW),
+        .AW (AW)
+    ) umi_demux_i (
+        .select             (select),
+
+        .umi_in_valid       (umi_in_valid),
+        .umi_in_cmd         (umi_in_cmd),
+        .umi_in_dstaddr     (umi_in_dstaddr),
+        .umi_in_srcaddr     (umi_in_srcaddr),
+        .umi_in_data        (umi_in_data),
+        .umi_in_ready       (umi_in_ready),
+
+        .umi_out_valid      (umi_out_valid),
+        .umi_out_cmd        (umi_out_cmd),
+        .umi_out_dstaddr    (umi_out_dstaddr),
+        .umi_out_srcaddr    (umi_out_srcaddr),
+        .umi_out_data       (umi_out_data),
+        .umi_out_ready      (umi_out_ready)
+    );
+
+    // waveform dump
+    `SB_SETUP_PROBES
+
+    // auto-stop
+    auto_stop_sim auto_stop_sim_i (.clk(clk));
+
+endmodule

--- a/umi/sumi/testbench/testbench_demux.sv
+++ b/umi/sumi/testbench/testbench_demux.sv
@@ -122,6 +122,9 @@ module testbench (
         );
 
         initial begin
+            `ifndef VERILATOR
+                #1;
+            `endif
             demux_out[i].umi_tx_i.init($sformatf("rtl2client_%0d.q", i));
             demux_out[i].umi_tx_i.set_ready_mode(ready_mode);
         end

--- a/umi/sumi/testbench/testbench_demux.sv
+++ b/umi/sumi/testbench/testbench_demux.sv
@@ -95,7 +95,7 @@ module testbench (
         .ready      (umi_in_ready)
     );
 
-    assign select = umi_in_dstaddr[40+:M];
+    assign select = {{(M-1){1'b0}}, 1'b1}<<umi_in_dstaddr[40+:$clog2(M)];
 
     initial begin
         `ifndef VERILATOR

--- a/umi/sumi/testbench/testbench_mux.sv
+++ b/umi/sumi/testbench/testbench_mux.sv
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright 2024 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ * - Simple umi mux testbench
+ *
+ ******************************************************************************/
+
+module testbench (
+`ifdef VERILATOR
+    input clk
+`endif
+);
+
+`include "switchboard.vh"
+
+    localparam N  = 4;
+    localparam DW = 256;
+    localparam CW = 32;
+    localparam AW = 64;
+
+    localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
+
+    reg     nreset;
+
+    initial begin
+        nreset   = 1'b0;
+    end // initial begin
+
+    // Bring up reset and the go signal on the first clock cycle
+    always @(negedge clk) begin
+        nreset <= nreset | 1'b1;
+    end
+
+    // Initialize UMI
+    integer valid_mode, ready_mode;
+
+    initial begin
+        /* verilator lint_off IGNOREDRETURN */
+        if (!$value$plusargs("valid_mode=%d", valid_mode)) begin
+            valid_mode = 2;  // default if not provided as a plusarg
+        end
+
+        if (!$value$plusargs("ready_mode=%d", ready_mode)) begin
+            ready_mode = 2;  // default if not provided as a plusarg
+        end
+        /* verilator lint_on IGNOREDRETURN */
+    end
+
+    wire [N-1:0]    umi_in_valid;
+    wire [N*CW-1:0] umi_in_cmd;
+    wire [N*AW-1:0] umi_in_dstaddr;
+    wire [N*AW-1:0] umi_in_srcaddr;
+    wire [N*DW-1:0] umi_in_data;
+    wire [N-1:0]    umi_in_ready;
+
+    wire            umi_out_valid;
+    wire [CW-1:0]   umi_out_cmd;
+    wire [AW-1:0]   umi_out_dstaddr;
+    wire [AW-1:0]   umi_out_srcaddr;
+    wire [DW-1:0]   umi_out_data;
+    wire            umi_out_ready;
+
+    ///////////////////////////////////////////
+    // Host side umi agents
+    ///////////////////////////////////////////
+
+    genvar          i;
+
+    generate
+    for(i = 0; i < N; i = i + 1) begin: mux_in
+        umi_rx_sim #(
+            .VALID_MODE_DEFAULT (2),
+            .DW                 (DW)
+        ) umi_rx_i (
+            .clk        (clk),
+
+            .valid      (umi_in_valid[i]),
+            .cmd        (umi_in_cmd[i*CW+:CW]),
+            .dstaddr    (umi_in_dstaddr[i*AW+:AW]),
+            .srcaddr    (umi_in_srcaddr[i*AW+:AW]),
+            .data       (umi_in_data[i*DW+:DW]),
+            .ready      (umi_in_ready[i])
+        );
+
+        initial begin
+            `ifndef VERILATOR
+                #1;
+            `endif
+            mux_in[i].umi_rx_i.init($sformatf("client2rtl_%0d.q", i));
+            mux_in[i].umi_rx_i.set_valid_mode(valid_mode);
+        end
+    end
+    endgenerate
+
+    umi_tx_sim #(
+        .READY_MODE_DEFAULT (2),
+        .DW                 (DW)
+    ) umi_tx_i (
+        .clk        (clk),
+
+        .valid      (umi_out_valid),
+        .cmd        (umi_out_cmd),
+        .dstaddr    (umi_out_dstaddr),
+        .srcaddr    (umi_out_srcaddr),
+        .data       (umi_out_data),
+        .ready      (umi_out_ready)
+    );
+
+    initial begin
+        `ifndef VERILATOR
+            #1;
+        `endif
+        umi_tx_i.init("rtl2client_0.q");
+        umi_tx_i.set_ready_mode(ready_mode);
+    end
+
+    // UMI Demux
+    umi_mux #(
+        .N  (N),
+        .DW (DW),
+        .CW (CW),
+        .AW (AW)
+    ) umi_mux_i (
+        .clk                (clk),
+        .nreset             (nreset),
+        .arbmode            (2'b00),
+        .arbmask            ({N{1'b0}}),
+
+        .umi_in_valid       (umi_in_valid),
+        .umi_in_cmd         (umi_in_cmd),
+        .umi_in_dstaddr     (umi_in_dstaddr),
+        .umi_in_srcaddr     (umi_in_srcaddr),
+        .umi_in_data        (umi_in_data),
+        .umi_in_ready       (umi_in_ready),
+
+        .umi_out_valid      (umi_out_valid),
+        .umi_out_cmd        (umi_out_cmd),
+        .umi_out_dstaddr    (umi_out_dstaddr),
+        .umi_out_srcaddr    (umi_out_srcaddr),
+        .umi_out_data       (umi_out_data),
+        .umi_out_ready      (umi_out_ready)
+    );
+
+    // waveform dump
+    `SB_SETUP_PROBES
+
+    // auto-stop
+    auto_stop_sim auto_stop_sim_i (.clk(clk));
+
+endmodule

--- a/umi/sumi/testbench/testbench_switch.sv
+++ b/umi/sumi/testbench/testbench_switch.sv
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright 2024 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ * - Simple umi switch testbench
+ *
+ ******************************************************************************/
+
+module testbench (
+`ifdef VERILATOR
+    input clk
+`endif
+);
+
+`include "switchboard.vh"
+
+    parameter integer N     = 4;
+    parameter integer M     = 4;
+    parameter integer DW    = 256;
+    parameter integer AW    = 64;
+    parameter integer CW    = 32;
+
+    localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
+
+    reg             nreset;
+
+    wire [N*M-1:0]  umi_in_valid;
+    wire [N*CW-1:0] umi_in_cmd;
+    wire [N*AW-1:0] umi_in_dstaddr;
+    wire [N*AW-1:0] umi_in_srcaddr;
+    wire [N*DW-1:0] umi_in_data;
+    wire [N-1:0]    umi_in_ready;
+
+    wire [M-1:0]    umi_out_valid;
+    wire [M*CW-1:0] umi_out_cmd;
+    wire [M*AW-1:0] umi_out_dstaddr;
+    wire [M*AW-1:0] umi_out_srcaddr;
+    wire [M*DW-1:0] umi_out_data;
+    wire [M-1:0]    umi_out_ready;
+
+    // Initialize UMI
+    integer valid_mode, ready_mode;
+
+    initial begin
+        /* verilator lint_off IGNOREDRETURN */
+        if (!$value$plusargs("valid_mode=%d", valid_mode)) begin
+            valid_mode = 2;  // default if not provided as a plusarg
+        end
+
+        if (!$value$plusargs("ready_mode=%d", ready_mode)) begin
+            ready_mode = 2;  // default if not provided as a plusarg
+        end
+        /* verilator lint_on IGNOREDRETURN */
+    end
+
+    ///////////////////////////////////////////
+    // Host side umi agents
+    ///////////////////////////////////////////
+    genvar  i, j;
+
+    generate
+    for(i = 0; i < N; i = i + 1) begin: switch_in
+
+        wire umi_valid;
+
+        umi_rx_sim #(
+            .VALID_MODE_DEFAULT (2),
+            .DW                 (DW)
+        ) umi_rx_i (
+            .clk        (clk),
+
+            .valid      (umi_valid),
+            .cmd        (umi_in_cmd[i*CW+:CW]),
+            .dstaddr    (umi_in_dstaddr[i*AW+:AW]),
+            .srcaddr    (umi_in_srcaddr[i*AW+:AW]),
+            .data       (umi_in_data[i*DW+:DW]),
+            .ready      (umi_in_ready[i])
+        );
+
+        for (j = 0; j < M; j = j + 1) begin: request
+            assign umi_in_valid[j*N + i] = umi_valid &
+                                           (umi_in_dstaddr[i*AW+40+:16] == j);
+        end
+
+        initial begin
+            `ifndef VERILATOR
+                #1;
+            `endif
+            switch_in[i].umi_rx_i.init($sformatf("client2rtl_%0d.q", i));
+            switch_in[i].umi_rx_i.set_valid_mode(valid_mode);
+        end
+    end
+    endgenerate
+
+    generate
+    for(i = 0; i < M; i = i + 1) begin: switch_out
+        umi_tx_sim #(
+            .READY_MODE_DEFAULT (2),
+            .DW                 (DW)
+        ) umi_tx_i (
+            .clk        (clk),
+
+            .valid      (umi_out_valid[i]),
+            .cmd        (umi_out_cmd[i*CW+:CW]),
+            .dstaddr    (umi_out_dstaddr[i*AW+:AW]),
+            .srcaddr    (umi_out_srcaddr[i*AW+:AW]),
+            .data       (umi_out_data[i*DW+:DW]),
+            .ready      (umi_out_ready[i])
+        );
+
+        initial begin
+            `ifndef VERILATOR
+                #1;
+            `endif
+            switch_out[i].umi_tx_i.init($sformatf("rtl2client_%0d.q", i));
+            switch_out[i].umi_tx_i.set_ready_mode(ready_mode);
+        end
+    end
+    endgenerate
+
+    // instantiate dut with UMI ports
+    umi_switch #(
+        .N      (N),
+        .M      (M),
+        .MASK   (0),
+        .DW     (DW),
+        .CW     (CW),
+        .AW     (AW)
+    ) umi_switch_i (
+        .clk                (clk),
+        .nreset             (nreset),
+        .arbmode            (2'b00),
+        .arbmask            ('b0),
+
+        .umi_in_valid       (umi_in_valid),
+        .umi_in_cmd         (umi_in_cmd),
+        .umi_in_dstaddr     (umi_in_dstaddr),
+        .umi_in_srcaddr     (umi_in_srcaddr),
+        .umi_in_data        (umi_in_data),
+        .umi_in_ready       (umi_in_ready),
+
+        .umi_out_valid      (umi_out_valid),
+        .umi_out_cmd        (umi_out_cmd),
+        .umi_out_dstaddr    (umi_out_dstaddr),
+        .umi_out_srcaddr    (umi_out_srcaddr),
+        .umi_out_data       (umi_out_data),
+        .umi_out_ready      (umi_out_ready)
+    );
+
+    // reset
+    initial begin
+        nreset   = 1'b0;
+    end // initial begin
+
+    // Bring up reset on the first clock cycle
+    always @(negedge clk) begin
+        nreset <= nreset | 1'b1;
+    end
+
+    // waveform dump
+    `SB_SETUP_PROBES
+
+    // auto-stop
+    auto_stop_sim auto_stop_sim_i (.clk(clk));
+
+endmodule

--- a/umi/sumi/testbench/testbench_umi_ram.sv
+++ b/umi/sumi/testbench/testbench_umi_ram.sv
@@ -23,8 +23,12 @@
 `default_nettype none
 
 module testbench (
-                  input clk
-                  );
+`ifdef VERILATOR
+    input clk
+`endif
+);
+
+`include "switchboard.vh"
 
    parameter integer N=5;
    parameter integer CW=32;
@@ -33,8 +37,18 @@ module testbench (
    parameter integer CTRLW=8;
    parameter integer RAMDEPTH=512;
 
+   localparam PERIOD_CLK   = 10;
+
+`ifndef VERILATOR
+    // Generate clock for non verilator sim tools
+    reg clk;
+
+    initial
+        clk  = 1'b0;
+    always #(PERIOD_CLK/2) clk = ~clk;
+`endif
+
    reg                  nreset;
-   reg                  go;
 
    wire [N-1:0]         udev_req_valid;
    wire [N*CW-1:0]      udev_req_cmd;
@@ -52,6 +66,21 @@ module testbench (
 
    wire [CTRLW-1:0]  sram_ctrl = 8'b0;
    wire [1:0]        mode = 2'b10;
+
+   // Initialize valid and ready modes
+   integer valid_mode, ready_mode;
+
+   initial begin
+      /* verilator lint_off IGNOREDRETURN */
+      if (!$value$plusargs("valid_mode=%d", valid_mode)) begin
+         valid_mode = 2;  // default if not provided as a plusarg
+      end
+
+      if (!$value$plusargs("ready_mode=%d", ready_mode)) begin
+         ready_mode = 2;  // default if not provided as a plusarg
+      end
+      /* verilator lint_on IGNOREDRETURN */
+   end
 
    ///////////////////////////////////////////
    // Host side umi agents
@@ -83,6 +112,16 @@ module testbench (
                        .data(udev_resp_data[i*DW+:DW]),
                        .ready(udev_resp_ready[i])
                        );
+
+        initial begin
+           `ifndef VERILATOR
+              #1;
+           `endif
+           UMI_AGENTS_GEN[i].host_umi_rx_i.init($sformatf("host2dut_%0d.q", i));
+           UMI_AGENTS_GEN[i].host_umi_rx_i.set_valid_mode(valid_mode);
+           UMI_AGENTS_GEN[i].host_umi_tx_i.init($sformatf("dut2host_%0d.q", i));
+           UMI_AGENTS_GEN[i].host_umi_tx_i.set_ready_mode(ready_mode);
+        end
    end
    endgenerate
 
@@ -115,71 +154,23 @@ module testbench (
              .udev_req_data       (udev_req_data[N*DW-1:0]),
              .udev_resp_ready     (udev_resp_ready[N-1:0]));
 
-            // Initialize UMI
-   integer valid_mode, ready_mode;
-
-   initial begin
-      /* verilator lint_off IGNOREDRETURN */
-      if (!$value$plusargs("valid_mode=%d", valid_mode)) begin
-         valid_mode = 2;  // default if not provided as a plusarg
-      end
-
-      if (!$value$plusargs("ready_mode=%d", ready_mode)) begin
-         ready_mode = 2;  // default if not provided as a plusarg
-      end
-
-      UMI_AGENTS_GEN[0].host_umi_rx_i.init("host2dut_0.q");
-      UMI_AGENTS_GEN[0].host_umi_rx_i.set_valid_mode(valid_mode);
-      UMI_AGENTS_GEN[1].host_umi_rx_i.init("host2dut_1.q");
-      UMI_AGENTS_GEN[1].host_umi_rx_i.set_valid_mode(valid_mode);
-      UMI_AGENTS_GEN[2].host_umi_rx_i.init("host2dut_2.q");
-      UMI_AGENTS_GEN[2].host_umi_rx_i.set_valid_mode(valid_mode);
-      UMI_AGENTS_GEN[3].host_umi_rx_i.init("host2dut_3.q");
-      UMI_AGENTS_GEN[3].host_umi_rx_i.set_valid_mode(valid_mode);
-      UMI_AGENTS_GEN[4].host_umi_rx_i.init("host2dut_4.q");
-      UMI_AGENTS_GEN[4].host_umi_rx_i.set_valid_mode(valid_mode);
-
-      UMI_AGENTS_GEN[0].host_umi_tx_i.init("dut2host_0.q");
-      UMI_AGENTS_GEN[0].host_umi_tx_i.set_ready_mode(ready_mode);
-      UMI_AGENTS_GEN[1].host_umi_tx_i.init("dut2host_1.q");
-      UMI_AGENTS_GEN[1].host_umi_tx_i.set_ready_mode(ready_mode);
-      UMI_AGENTS_GEN[2].host_umi_tx_i.init("dut2host_2.q");
-      UMI_AGENTS_GEN[2].host_umi_tx_i.set_ready_mode(ready_mode);
-      UMI_AGENTS_GEN[3].host_umi_tx_i.init("dut2host_3.q");
-      UMI_AGENTS_GEN[3].host_umi_tx_i.set_ready_mode(ready_mode);
-      UMI_AGENTS_GEN[4].host_umi_tx_i.init("dut2host_4.q");
-      UMI_AGENTS_GEN[4].host_umi_tx_i.set_ready_mode(ready_mode);
-      /* verilator lint_on IGNOREDRETURN */
-   end
-
-   // VCD
-
+   // reset
    initial
      begin
         nreset   = 1'b0;
-        go       = 1'b0;
      end // initial begin
 
-   // Bring up reset and the go signal on the first clock cycle
+   // Bring up reset on the first clock cycle
    always @(negedge clk)
      begin
         nreset <= nreset | 1'b1;
-        go <= 1'b1;
      end
 
-   // control block
-   initial
-     begin
-        if ($test$plusargs("trace"))
-          begin
-             $dumpfile("testbench.fst");
-             $dumpvars(0, testbench);
-          end
-     end
+    // waveform dump
+    `SB_SETUP_PROBES
 
-   // auto-stop
-
-   auto_stop_sim auto_stop_sim_i (.clk(clk));
+    // auto-stop
+    auto_stop_sim auto_stop_sim_i (.clk(clk));
 
 endmodule
 // Local Variables:

--- a/umi/sumi/tests/test_demux.py
+++ b/umi/sumi/tests/test_demux.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 Zero ASIC
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+import pytest
+import multiprocessing
+import numpy as np
+from switchboard import UmiTxRx, random_umi_packet, delete_queue
+
+
+def umi_send(umi_q, n, ports, seed):
+
+    np.random.seed(seed)
+
+    tee = [UmiTxRx(f'tee_{x}.q', '') for x in range(ports)]
+
+    for count in range(n*ports):
+        dstport = np.random.randint(0, ports)
+        dstaddr = (2**8)*np.random.randint(0, 2**32) + (2**(40+dstport))
+        srcaddr = (2**8)*np.random.randint(0, 2**32) + (2**(40+ports))
+        txp = random_umi_packet(dstaddr=dstaddr, srcaddr=srcaddr)
+        print(f"Sending #{count} cmd: 0x{txp.cmd:08x} srcaddr: 0x{srcaddr:08x} "
+              f"dstaddr: 0x{dstaddr:08x} to port {dstport}")
+        # send the packet to both simulation and local queues
+        umi_q.send(txp)
+        tee[dstport].send(txp)
+
+
+def test_demux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
+    n = 100
+    ports = 4
+
+    for x in range(ports):
+        delete_queue(f'tee_{x}.q')
+
+    # instantiate TX and RX queues.  note that these can be instantiated without
+    # specifying a URI, in which case the URI can be specified later via the
+    # "init" method
+
+    umi = UmiTxRx('client2rtl_0.q', '', fresh=True)
+    tee = [UmiTxRx('', f'tee_{x}.q') for x in range(ports)]
+    recvq = [UmiTxRx('', f'rtl2client_{x}.q', fresh=True) for x in range(ports)]
+
+    # launch the simulation
+    sumi_dut.simulate(
+            plusargs=[('valid_mode', sb_umi_valid_mode),
+                      ('ready_mode', sb_umi_ready_mode)])
+
+    print("### Starting test ###")
+
+    send_proc = multiprocessing.Process(target=umi_send,
+                                        args=(umi, n, ports, random_seed,))
+
+    send_proc.start()
+
+    recv_queue = [[] for i in range(ports)]
+    send_queue = [[] for i in range(ports)]
+
+    nrecv = 0
+    nsend = 0
+    while (nrecv < ports*n) or (nsend < ports*n):
+        for i in range(ports):
+            rxp = recvq[i].recv(blocking=False)
+            if rxp is not None:
+                if nrecv >= ports*n:
+                    print(f'Unexpected packet received {nrecv}')
+                    raise Exception(f'Unexpected packet received {nrecv}')
+                else:
+                    recv_src = (rxp.srcaddr >> 40)
+                    print(f"port {i} receiving srcaddr: 0x{rxp.srcaddr:08x} "
+                          f"dstaddr: 0x{rxp.dstaddr:08x} src: {recv_src} #{nrecv}")
+                    recv_queue[i].append(rxp)
+                    nrecv += 1
+
+        for i in range(ports):
+            txp = tee[i].recv(blocking=False)
+            if txp is not None:
+                if nsend >= ports*n:
+                    raise Exception('Unexpected packet sent')
+                else:
+                    send_dst = (txp.dstaddr >> 40)
+                    send_queue[i].append(txp)
+                    nsend += 1
+
+    # join Tx sender
+    send_proc.join()
+
+    for i in range(ports):
+        if len(send_queue[i]) != len(recv_queue[i]):
+            print(f"packets sent: {len(send_queue[i])} packets received: {len(recv_queue[i])}")
+        assert len(send_queue[i]) == len(recv_queue[i])
+        for txp, rxp in zip(send_queue[i], recv_queue[i]):
+            assert txp == rxp
+        print(f"Received {len(recv_queue[i])} packets at port {i}")
+
+
+if __name__ == '__main__':
+    pytest.main(['-s', '-q', __file__])

--- a/umi/sumi/tests/test_demux.py
+++ b/umi/sumi/tests/test_demux.py
@@ -10,9 +10,9 @@ from umi_common import umi_send
 
 
 def test_demux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
-    n = 4000 # Number of transactions to be sent to each demux input port
-    in_ports = 1 # Number of input ports. Fixed to 1 for demux
-    out_ports = 4 # Number of output ports. Must match testbench
+    n = 4000  # Number of transactions to be sent to each demux input port
+    in_ports = 1  # Number of input ports. Fixed to 1 for demux
+    out_ports = 4  # Number of output ports. Must match testbench
 
     for x in range(in_ports):
         delete_queue(f'client2rtl_{x}.q')

--- a/umi/sumi/tests/test_demux.py
+++ b/umi/sumi/tests/test_demux.py
@@ -34,13 +34,10 @@ def test_demux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
     for x in range(ports):
         delete_queue(f'tee_{x}.q')
 
-    # instantiate TX and RX queues.  note that these can be instantiated without
-    # specifying a URI, in which case the URI can be specified later via the
-    # "init" method
-
+    # Instantiate TX and RX queues
     umi = UmiTxRx('client2rtl_0.q', '', fresh=True)
-    tee = [UmiTxRx('', f'tee_{x}.q') for x in range(ports)]
     recvq = [UmiTxRx('', f'rtl2client_{x}.q', fresh=True) for x in range(ports)]
+    tee = [UmiTxRx('', f'tee_{x}.q') for x in range(ports)]
 
     # launch the simulation
     sumi_dut.simulate(
@@ -79,7 +76,6 @@ def test_demux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
                 if nsend >= ports*n:
                     raise Exception('Unexpected packet sent')
                 else:
-                    send_dst = (txp.dstaddr >> 40)
                     send_queue[i].append(txp)
                     nsend += 1
 

--- a/umi/sumi/tests/test_mux.py
+++ b/umi/sumi/tests/test_mux.py
@@ -35,7 +35,7 @@ def test_mux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
     # Instantiate TX and RX queues
     umi = [UmiTxRx(f'client2rtl_{x}.q', '', fresh=True) for x in range(ports)]
-    recvq = UmiTxRx('', f'rtl2client_0.q', fresh=True)
+    recvq = UmiTxRx('', 'rtl2client_0.q', fresh=True)
     tee = [UmiTxRx('', f'tee_{x}.q') for x in range(ports)]
 
     # launch the simulation

--- a/umi/sumi/tests/test_mux.py
+++ b/umi/sumi/tests/test_mux.py
@@ -5,38 +5,22 @@
 
 import pytest
 import multiprocessing
-import numpy as np
-from switchboard import UmiTxRx, random_umi_packet, delete_queue
-
-
-def umi_send(umi_q, n, x, seed):
-
-    np.random.seed(seed)
-
-    tee = UmiTxRx(f'tee_{x}.q', '')
-
-    for count in range(n):
-        dstaddr = (2**8)*np.random.randint(0, 2**32)
-        srcaddr = (2**8)*np.random.randint(0, 2**32) + x*(2**(40))
-        txp = random_umi_packet(dstaddr=dstaddr, srcaddr=srcaddr)
-        print(f"Sending #{count} cmd: 0x{txp.cmd:08x} srcaddr: 0x{srcaddr:08x} "
-              f"dstaddr: 0x{dstaddr:08x}")
-        # send the packet to both simulation and local queues
-        umi_q.send(txp)
-        tee.send(txp)
+from switchboard import UmiTxRx, delete_queue
+from umi_common import umi_send
 
 
 def test_mux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
-    n = 100
-    ports = 4
+    n = 1000 # Number of transactions to be sent to each mux input port
+    in_ports = 4 # Number of input ports. Must match testbench
+    out_ports = 1 # Number of output ports. Fixed to 1 for mux
 
-    for x in range(ports):
+    for x in range(in_ports):
+        delete_queue(f'client2rtl_{x}.q')
         delete_queue(f'tee_{x}.q')
 
     # Instantiate TX and RX queues
-    umi = [UmiTxRx(f'client2rtl_{x}.q', '', fresh=True) for x in range(ports)]
-    recvq = UmiTxRx('', 'rtl2client_0.q', fresh=True)
-    tee = [UmiTxRx('', f'tee_{x}.q') for x in range(ports)]
+    umi = [UmiTxRx('', f'rtl2client_{x}.q', fresh=True) for x in range(out_ports)]
+    tee = [UmiTxRx('', f'tee_{x}.q') for x in range(in_ports)]
 
     # launch the simulation
     sumi_dut.simulate(
@@ -47,35 +31,36 @@ def test_mux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
     send_procs = []
 
-    for x in range(ports):
+    for x in range(in_ports):
         send_procs.append(multiprocessing.Process(target=umi_send,
-                                                  args=(umi[x], n, x, (random_seed+x),)))
+                                                  args=(x, n, out_ports, (random_seed+x),)))
 
     for proc in send_procs:
         proc.start()
 
-    recv_queue = [[] for i in range(ports)]
-    send_queue = [[] for i in range(ports)]
+    recv_queue = [[] for i in range(in_ports)]
+    send_queue = [[] for i in range(in_ports)]
 
     nrecv = 0
     nsend = 0
-    while (nrecv < ports*n) or (nsend < ports*n):
-        rxp = recvq.recv(blocking=False)
-        if rxp is not None:
-            if nrecv >= ports*n:
-                print(f'Unexpected packet received {nrecv}')
-                raise Exception(f'Unexpected packet received {nrecv}')
-            else:
-                recv_src = (rxp.srcaddr >> 40)
-                print(f"Receiving srcaddr: 0x{rxp.srcaddr:08x} "
-                      f"dstaddr: 0x{rxp.dstaddr:08x} src: {recv_src} #{nrecv}")
-                recv_queue[recv_src].append(rxp)
-                nrecv += 1
+    while (nrecv < in_ports*n) or (nsend < in_ports*n):
+        for i in range(out_ports):
+            rxp = umi[i].recv(blocking=False)
+            if rxp is not None:
+                if nrecv >= in_ports*n:
+                    print(f'Unexpected packet received {nrecv}')
+                    raise Exception(f'Unexpected packet received {nrecv}')
+                else:
+                    recv_src = (rxp.srcaddr >> 40)
+                    print(f"port {i} receiving srcaddr: 0x{rxp.srcaddr:08x} "
+                          f"dstaddr: 0x{rxp.dstaddr:08x} src: {recv_src} #{nrecv}")
+                    recv_queue[recv_src].append(rxp)
+                    nrecv += 1
 
-        for i in range(ports):
+        for i in range(in_ports):
             txp = tee[i].recv(blocking=False)
             if txp is not None:
-                if nsend >= ports*n:
+                if nsend >= in_ports*n:
                     raise Exception('Unexpected packet sent')
                 else:
                     send_queue[i].append(txp)
@@ -85,7 +70,7 @@ def test_mux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
     for proc in send_procs:
         proc.join()
 
-    for i in range(ports):
+    for i in range(in_ports):
         if len(send_queue[i]) != len(recv_queue[i]):
             print(f"packets sent: {len(send_queue[i])} packets received: {len(recv_queue[i])}")
         assert len(send_queue[i]) == len(recv_queue[i])

--- a/umi/sumi/tests/test_mux.py
+++ b/umi/sumi/tests/test_mux.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 Zero ASIC
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+import pytest
+import multiprocessing
+import numpy as np
+from switchboard import UmiTxRx, random_umi_packet, delete_queue
+
+
+def umi_send(umi_q, n, x, seed):
+
+    np.random.seed(seed)
+
+    tee = UmiTxRx(f'tee_{x}.q', '')
+
+    for count in range(n):
+        dstaddr = (2**8)*np.random.randint(0, 2**32)
+        srcaddr = (2**8)*np.random.randint(0, 2**32) + x*(2**(40))
+        txp = random_umi_packet(dstaddr=dstaddr, srcaddr=srcaddr)
+        print(f"Sending #{count} cmd: 0x{txp.cmd:08x} srcaddr: 0x{srcaddr:08x} "
+              f"dstaddr: 0x{dstaddr:08x}")
+        # send the packet to both simulation and local queues
+        umi_q.send(txp)
+        tee.send(txp)
+
+
+def test_mux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
+    n = 100
+    ports = 4
+
+    for x in range(ports):
+        delete_queue(f'tee_{x}.q')
+
+    # Instantiate TX and RX queues
+    umi = [UmiTxRx(f'client2rtl_{x}.q', '', fresh=True) for x in range(ports)]
+    recvq = UmiTxRx('', f'rtl2client_0.q', fresh=True)
+    tee = [UmiTxRx('', f'tee_{x}.q') for x in range(ports)]
+
+    # launch the simulation
+    sumi_dut.simulate(
+            plusargs=[('valid_mode', sb_umi_valid_mode),
+                      ('ready_mode', sb_umi_ready_mode)])
+
+    print("### Starting test ###")
+
+    send_procs = []
+
+    for x in range(ports):
+        send_procs.append(multiprocessing.Process(target=umi_send,
+                                                  args=(umi[x], n, x, (random_seed+x),)))
+
+    for proc in send_procs:
+        proc.start()
+
+    recv_queue = [[] for i in range(ports)]
+    send_queue = [[] for i in range(ports)]
+
+    nrecv = 0
+    nsend = 0
+    while (nrecv < ports*n) or (nsend < ports*n):
+        rxp = recvq.recv(blocking=False)
+        if rxp is not None:
+            if nrecv >= ports*n:
+                print(f'Unexpected packet received {nrecv}')
+                raise Exception(f'Unexpected packet received {nrecv}')
+            else:
+                recv_src = (rxp.srcaddr >> 40)
+                print(f"Receiving srcaddr: 0x{rxp.srcaddr:08x} "
+                      f"dstaddr: 0x{rxp.dstaddr:08x} src: {recv_src} #{nrecv}")
+                recv_queue[recv_src].append(rxp)
+                nrecv += 1
+
+        for i in range(ports):
+            txp = tee[i].recv(blocking=False)
+            if txp is not None:
+                if nsend >= ports*n:
+                    raise Exception('Unexpected packet sent')
+                else:
+                    send_queue[i].append(txp)
+                    nsend += 1
+
+    # join Tx senders
+    for proc in send_procs:
+        proc.join()
+
+    for i in range(ports):
+        if len(send_queue[i]) != len(recv_queue[i]):
+            print(f"packets sent: {len(send_queue[i])} packets received: {len(recv_queue[i])}")
+        assert len(send_queue[i]) == len(recv_queue[i])
+        for txp, rxp in zip(send_queue[i], recv_queue[i]):
+            assert txp == rxp
+        print(f"Received {len(recv_queue[i])} packets at port {i}")
+
+
+if __name__ == '__main__':
+    pytest.main(['-s', '-q', __file__])

--- a/umi/sumi/tests/test_mux.py
+++ b/umi/sumi/tests/test_mux.py
@@ -10,9 +10,9 @@ from umi_common import umi_send
 
 
 def test_mux(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
-    n = 1000 # Number of transactions to be sent to each mux input port
-    in_ports = 4 # Number of input ports. Must match testbench
-    out_ports = 1 # Number of output ports. Fixed to 1 for mux
+    n = 1000  # Number of transactions to be sent to each mux input port
+    in_ports = 4  # Number of input ports. Must match testbench
+    out_ports = 1  # Number of output ports. Fixed to 1 for mux
 
     for x in range(in_ports):
         delete_queue(f'client2rtl_{x}.q')

--- a/umi/sumi/tests/test_regif.py
+++ b/umi/sumi/tests/test_regif.py
@@ -54,7 +54,7 @@ def apply_atomic(origdata, atomicdata, operation, maxrange):
 
 def test_regif(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    n = 100 # Number of reads, atomic txns and writes each from the register file
+    n = 100  # Number of reads, atomic txns and writes each from the register file
 
     np.random.seed(random_seed)
 

--- a/umi/sumi/tests/test_regif.py
+++ b/umi/sumi/tests/test_regif.py
@@ -54,7 +54,7 @@ def apply_atomic(origdata, atomicdata, operation, maxrange):
 
 def test_regif(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    n = 100
+    n = 100 # Number of reads, atomic txns and writes each from the register file
 
     np.random.seed(random_seed)
 

--- a/umi/sumi/tests/test_regif.py
+++ b/umi/sumi/tests/test_regif.py
@@ -3,37 +3,9 @@
 # Copyright (C) 2023 Zero ASIC
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-import random
+import pytest
 import numpy as np
-from argparse import ArgumentParser
-from switchboard import SbDut, UmiTxRx, delete_queue, verilator_run
-from umi import sumi
-
-
-def build_testbench():
-    dut = SbDut('testbench', trace=False, default_main=True)
-
-    # Set up inputs
-    dut.input('sumi/testbench/testbench_regif.sv', package='umi')
-
-    dut.use(sumi)
-
-    # Verilator configuration
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', 'sumi/testbench/config.vlt', package='umi')
-#    dut.set('option', 'relax', True)
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '--prof-cfuncs')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-CFLAGS')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-DVL_DEBUG')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-Wall')
-
-    # Settings - enable tracing
-    dut.set('tool', 'verilator', 'task', 'compile', 'var', 'trace', True)
-    dut.set('tool', 'verilator', 'task', 'compile', 'var', 'trace_type', 'fst')
-
-    # Build simulator
-    dut.run()
-
-    return dut.find_result('vexe', step='compile')
+from switchboard import UmiTxRx
 
 
 def apply_atomic(origdata, atomicdata, operation, maxrange):
@@ -80,21 +52,22 @@ def apply_atomic(origdata, atomicdata, operation, maxrange):
     return tempval
 
 
-def main(vldmode="2", rdymode="2", n=100, host2dut="host2dut_0.q", dut2host="dut2host_0.q"):
-    # clean up old queues if present
-    for q in [host2dut, dut2host]:
-        delete_queue(q)
+def test_regif(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    verilator_bin = build_testbench()
+    n = 100
+
+    np.random.seed(random_seed)
 
     # launch the simulation
-    verilator_run(verilator_bin, plusargs=['trace', ('valid_mode', vldmode), ('ready_mode', rdymode)])
+    sumi_dut.simulate(
+            plusargs=[('valid_mode', sb_umi_valid_mode),
+                      ('ready_mode', sb_umi_ready_mode)])
 
     # instantiate TX and RX queues.  note that these can be instantiated without
     # specifying a URI, in which case the URI can be specified later via the
     # "init" method
 
-    host = UmiTxRx(host2dut, dut2host)
+    host = UmiTxRx("host2dut_0.q", "dut2host_0.q", fresh=True)
 
     print("### Starting test ###")
 
@@ -102,12 +75,12 @@ def main(vldmode="2", rdymode="2", n=100, host2dut="host2dut_0.q", dut2host="dut
     for _ in range(n):
         addr = np.random.randint(0, 512) * 4
         # length should not cross the DW boundary - umi_mem_agent limitation
-        data = np.uint32(random.randrange(2**32-1))
+        data = np.random.randint(2**32, dtype=np.uint32)
 
         print(f"umi writing 0x{data:08x} to addr 0x{addr:08x}")
         host.write(addr, data)
         atomicopcode = np.random.randint(0, 9)
-        atomicdata = np.uint32(random.randrange(2**32-1))
+        atomicdata = np.random.randint(2**32, dtype=np.uint32)
         print(f"umi atomic opcode: {atomicopcode} data: {atomicdata:08x} to addr 0x{addr:08x}")
         atomicval = host.atomic(addr, atomicdata, atomicopcode)
         if not (atomicval == data):
@@ -121,17 +94,6 @@ def main(vldmode="2", rdymode="2", n=100, host2dut="host2dut_0.q", dut2host="dut
             print(f"ERROR umi read from addr 0x{addr:08x} expected {data} actual {val}")
             assert (val == data)
 
-    print("### TEST PASS ###")
-
 
 if __name__ == '__main__':
-    parser = ArgumentParser()
-    parser.add_argument('--vldmode', default='2')
-    parser.add_argument('--rdymode', default='2')
-    parser.add_argument('-n', type=int, default=10,
-                        help='Number of transactions to send during the test.')
-    args = parser.parse_args()
-
-    main(vldmode=args.vldmode,
-         rdymode=args.rdymode,
-         n=args.n)
+    pytest.main(['-s', '-q', __file__])

--- a/umi/sumi/tests/test_switch.py
+++ b/umi/sumi/tests/test_switch.py
@@ -10,9 +10,9 @@ from umi_common import umi_send
 
 
 def test_switch(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
-    n = 1000 # Number of transactions to be sent to each switch input port
-    in_ports = 4 # Number of input ports. Must match testbench
-    out_ports = 2 # Number of output ports. Must match testbench
+    n = 1000  # Number of transactions to be sent to each switch input port
+    in_ports = 4  # Number of input ports. Must match testbench
+    out_ports = 2  # Number of output ports. Must match testbench
 
     for x in range(in_ports):
         delete_queue(f'client2rtl_{x}.q')

--- a/umi/sumi/tests/test_umi_ram.py
+++ b/umi/sumi/tests/test_umi_ram.py
@@ -54,8 +54,8 @@ def apply_atomic(origdata, atomicdata, operation, maxrange):
 
 def test_umi_ram(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    ports = 5
-    n = 100
+    ports = 5 # Number of input ports of umi_ram. Must match testbench
+    n = 100 # Number of reads, atomic txns and writes each from the umi_ram
 
     np.random.seed(random_seed)
 

--- a/umi/sumi/tests/test_umi_ram.py
+++ b/umi/sumi/tests/test_umi_ram.py
@@ -3,36 +3,9 @@
 # Copyright (C) 2023 Zero ASIC
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
+import pytest
 import numpy as np
-from argparse import ArgumentParser
-from switchboard import SbDut, UmiTxRx, verilator_run
-from umi import sumi
-
-
-def build_testbench():
-    dut = SbDut('testbench', trace=False, default_main=True)
-
-    # Set up inputs
-    dut.input('sumi/testbench/testbench_umi_ram.sv', package='umi')
-
-    dut.use(sumi)
-
-    # Verilator configuration
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', 'sumi/testbench/config.vlt',
-            package='umi')
-#    dut.set('option', 'relax', True)
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '--prof-cfuncs')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-CFLAGS')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-DVL_DEBUG')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-Wall')
-
-    # Settings - enable tracing
-    dut.set('tool', 'verilator', 'task', 'compile', 'var', 'trace_type', 'fst')
-
-    # Build simulator
-    dut.run()
-
-    return dut.find_result('vexe', step='compile')
+from switchboard import UmiTxRx
 
 
 def apply_atomic(origdata, atomicdata, operation, maxrange):
@@ -79,22 +52,25 @@ def apply_atomic(origdata, atomicdata, operation, maxrange):
     return tempval
 
 
-def main(vldmode="2", rdymode="2", n=100):
+def test_umi_ram(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    verilator_bin = build_testbench()
+    ports = 5
+    n = 100
+
+    np.random.seed(random_seed)
 
     # launch the simulation
-    verilator_run(verilator_bin, plusargs=['trace',
-                                           ('valid_mode', vldmode),
-                                           ('ready_mode', rdymode)])
+    sumi_dut.simulate(
+            plusargs=[('valid_mode', sb_umi_valid_mode),
+                      ('ready_mode', sb_umi_ready_mode)])
 
     # instantiate TX and RX queues.  note that these can be instantiated without
     # specifying a URI, in which case the URI can be specified later via the
     # "init" method
 
-    host = [UmiTxRx(f'host2dut_{x}.q', f'dut2host_{x}.q', fresh=True) for x in range(5)]
+    host = [UmiTxRx(f'host2dut_{x}.q', f'dut2host_{x}.q', fresh=True) for x in range(ports)]
 
-    print("### Statring test ###")
+    print("### Starting test ###")
 
     avail_datatype = [np.uint8, np.uint16, np.uint32]
 
@@ -135,17 +111,6 @@ def main(vldmode="2", rdymode="2", n=100):
             print(f"ERROR umi read from addr 0x{addr:08x} expected {data} actual {val}")
             assert (np.array_equal(val, data))
 
-    print("### TEST PASS ###")
-
 
 if __name__ == '__main__':
-    parser = ArgumentParser()
-    parser.add_argument('--vldmode', default='2')
-    parser.add_argument('--rdymode', default='2')
-    parser.add_argument('-n', type=int, default=10,
-                        help='Number of transactions to send during the test.')
-    args = parser.parse_args()
-
-    main(vldmode=args.vldmode,
-         rdymode=args.rdymode,
-         n=args.n)
+    pytest.main(['-s', '-q', __file__])

--- a/umi/sumi/tests/test_umi_ram.py
+++ b/umi/sumi/tests/test_umi_ram.py
@@ -54,8 +54,8 @@ def apply_atomic(origdata, atomicdata, operation, maxrange):
 
 def test_umi_ram(sumi_dut, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    ports = 5 # Number of input ports of umi_ram. Must match testbench
-    n = 100 # Number of reads, atomic txns and writes each from the umi_ram
+    ports = 5  # Number of input ports of umi_ram. Must match testbench
+    n = 100  # Number of reads, atomic txns and writes each from the umi_ram
 
     np.random.seed(random_seed)
 

--- a/umi/sumi/tests/umi_common.py
+++ b/umi/sumi/tests/umi_common.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 Zero ASIC
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+import numpy as np
+from switchboard import UmiTxRx, random_umi_packet
+
+
+def umi_send(host_num, num_packets_to_send, num_out_ports, seed):
+
+    np.random.seed(seed)
+
+    umi = UmiTxRx(f'client2rtl_{host_num}.q', '')
+    tee = UmiTxRx(f'tee_{host_num}.q', '')
+
+    for count in range(num_packets_to_send):
+        dstport = np.random.randint(num_out_ports)
+        dstaddr = (2**8)*np.random.randint(2**32) + dstport*(2**40)
+        srcaddr = (2**8)*np.random.randint(2**32) + host_num*(2**40)
+        txp = random_umi_packet(dstaddr=dstaddr, srcaddr=srcaddr)
+        print(f"port {host_num} sending #{count} cmd: 0x{txp.cmd:08x} srcaddr: 0x{srcaddr:08x} "
+              f"dstaddr: 0x{dstaddr:08x} to port {dstport}")
+        # send the packet to both simulation and local queues
+        umi.send(txp)
+        tee.send(txp)


### PR DESCRIPTION
This PR adds testbenches and tests for umi_mux, umi_demux, and umi_switch.
Additionally, it converts umi_ram and umi_regif to pytest.