### PR TITLE
LUMI rtl and test changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ markers = [
 ]
 testpaths = [
     "tests",
-    "umi/sumi/tests"
+    "umi/sumi/tests",
+    "umi/lumi/tests"
 ]
 timeout = "300"

--- a/umi/conftest.py
+++ b/umi/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+import os
+import multiprocessing
+
+
+@pytest.fixture(autouse=True)
+def test_wrapper(tmp_path):
+    '''
+    Fixture that automatically runs each test in a test-specific temporary
+    directory to avoid clutter.
+    '''
+    try:
+        multiprocessing.set_start_method('fork')
+    except RuntimeError:
+        pass
+
+    topdir = os.getcwd()
+    os.chdir(tmp_path)
+
+    # Run the test.
+    yield
+
+    os.chdir(topdir)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--seed", type=int, action="store", help="Provide a fixed seed")
+
+
+@pytest.fixture
+def random_seed(request):
+    fixed_seed = request.config.getoption("--seed")
+    if fixed_seed is not None:
+        test_seed = fixed_seed
+    else:
+        test_seed = os.getpid()
+    print(f'Random seed used: {test_seed}')
+    yield test_seed
+    print(f'Random seed used: {test_seed}')

--- a/umi/lumi/rtl/lumi.v
+++ b/umi/lumi/rtl/lumi.v
@@ -141,7 +141,10 @@ module lumi
    wire [7:0]           csr_rxiowidth;
    wire                 csr_txcrdt_en;
    wire [15:0]          csr_txcrdt_intrvl;
-   wire [31:0]          csr_txcrdt_status;
+   wire [31:0]          csr_req_txcrdt_navail;
+   wire [31:0]          csr_resp_txcrdt_navail;
+   wire [31:0]          csr_req_txcrdt_avail;
+   wire [31:0]          csr_resp_txcrdt_avail;
    wire                 csr_txen;
    wire [7:0]           csr_txiowidth;
    wire [CW-1:0]        fifo2cb_cmd;
@@ -193,36 +196,39 @@ module lumi
                )
    lumi_regs(/*AUTOINST*/
              // Outputs
-             .udev_req_ready    (cb2regs_ready),         // Templated
-             .udev_resp_valid   (regs2cb_valid),         // Templated
-             .udev_resp_cmd     (regs2cb_cmd[CW-1:0]),   // Templated
-             .udev_resp_dstaddr (regs2cb_dstaddr[AW-1:0]), // Templated
-             .udev_resp_srcaddr (regs2cb_srcaddr[AW-1:0]), // Templated
-             .udev_resp_data    (regs2cb_data[RW-1:0]),  // Templated
-             .host_linkactive   (host_linkactive),
-             .csr_arbmode       (),                      // Templated
-             .csr_txen          (csr_txen),
-             .csr_txcrdt_en     (csr_txcrdt_en),
-             .csr_txiowidth     (csr_txiowidth[7:0]),
-             .csr_rxen          (csr_rxen),
-             .csr_rxiowidth     (csr_rxiowidth[7:0]),
-             .csr_txcrdt_intrvl (csr_txcrdt_intrvl[15:0]),
-             .csr_rxcrdt_req_init(csr_rxcrdt_req_init[15:0]),
-             .csr_rxcrdt_resp_init(csr_rxcrdt_resp_init[15:0]),
+             .udev_req_ready            (cb2regs_ready),         // Templated
+             .udev_resp_valid           (regs2cb_valid),         // Templated
+             .udev_resp_cmd             (regs2cb_cmd[CW-1:0]),   // Templated
+             .udev_resp_dstaddr         (regs2cb_dstaddr[AW-1:0]), // Templated
+             .udev_resp_srcaddr         (regs2cb_srcaddr[AW-1:0]), // Templated
+             .udev_resp_data            (regs2cb_data[RW-1:0]),  // Templated
+             .host_linkactive           (host_linkactive),
+             .csr_arbmode               (),                      // Templated
+             .csr_txen                  (csr_txen),
+             .csr_txcrdt_en             (csr_txcrdt_en),
+             .csr_txiowidth             (csr_txiowidth[7:0]),
+             .csr_rxen                  (csr_rxen),
+             .csr_rxiowidth             (csr_rxiowidth[7:0]),
+             .csr_txcrdt_intrvl         (csr_txcrdt_intrvl[15:0]),
+             .csr_rxcrdt_req_init       (csr_rxcrdt_req_init[15:0]),
+             .csr_rxcrdt_resp_init      (csr_rxcrdt_resp_init[15:0]),
              // Inputs
-             .devicemode        (devicemode),
-             .deviceready       (deviceready),
-             .nreset            (nreset),
-             .clk               (clk),
-             .udev_req_valid    (cb2regs_valid),         // Templated
-             .udev_req_cmd      (cb2regs_cmd[CW-1:0]),   // Templated
-             .udev_req_dstaddr  (cb2regs_dstaddr[AW-1:0]), // Templated
-             .udev_req_srcaddr  (cb2regs_srcaddr[AW-1:0]), // Templated
-             .udev_req_data     (cb2regs_data[RW-1:0]),  // Templated
-             .udev_resp_ready   (regs2cb_ready),         // Templated
-             .phy_linkactive    (phy_linkactive),
-             .phy_iow           (phy_iow[7:0]),
-             .csr_txcrdt_status (csr_txcrdt_status[31:0]));
+             .devicemode                (devicemode),
+             .deviceready               (deviceready),
+             .nreset                    (nreset),
+             .clk                       (clk),
+             .udev_req_valid            (cb2regs_valid),         // Templated
+             .udev_req_cmd              (cb2regs_cmd[CW-1:0]),   // Templated
+             .udev_req_dstaddr          (cb2regs_dstaddr[AW-1:0]), // Templated
+             .udev_req_srcaddr          (cb2regs_srcaddr[AW-1:0]), // Templated
+             .udev_req_data             (cb2regs_data[RW-1:0]),  // Templated
+             .udev_resp_ready           (regs2cb_ready),         // Templated
+             .phy_linkactive            (phy_linkactive),
+             .phy_iow                   (phy_iow[7:0]),
+             .csr_req_txcrdt_navail     (csr_req_txcrdt_navail),
+             .csr_resp_txcrdt_navail    (csr_resp_txcrdt_navail),
+             .csr_req_txcrdt_avail      (csr_req_txcrdt_avail),
+             .csr_resp_txcrdt_avail     (csr_resp_txcrdt_avail));
 
    //###########################
    // Register Crossbar
@@ -466,7 +472,10 @@ module lumi
            .umi_resp_in_ready   (uhost_resp_ready),      // Templated
            .phy_txdata          (phy_txdata[IOW-1:0]),
            .phy_txvld           (phy_txvld),
-           .csr_crdt_status     (csr_txcrdt_status[31:0]), // Templated
+           .csr_req_crdt_navail (csr_req_txcrdt_navail), // Templated
+           .csr_resp_crdt_navail(csr_resp_txcrdt_navail), // Templated
+           .csr_req_crdt_avail  (csr_req_txcrdt_avail), // Templated
+           .csr_resp_crdt_avail (csr_resp_txcrdt_avail), // Templated
            // Inputs
            .clk                 (clk),
            .nreset              (nreset),

--- a/umi/lumi/rtl/lumi_regmap.vh
+++ b/umi/lumi/rtl/lumi_regmap.vh
@@ -21,10 +21,13 @@
  ******************************************************************************/
 
 // registers (addr[7:0]), 32bit aligned
-localparam LUMI_CTRL        = 8'h00; // device configuration
-localparam LUMI_STATUS      = 8'h04; // device status
-localparam LUMI_TXMODE      = 8'h10; // tx operating mode
-localparam LUMI_RXMODE      = 8'h14; // rx operating mode
-localparam LUMI_CRDTINIT    = 8'h20; // Credit init value
-localparam LUMI_CRDTINTRVL  = 8'h24; // Credir update interval
-localparam LUMI_CRDTSTAT    = 8'h28; // Credit status
+localparam LUMI_CTRL           = 8'h00; // device configuration
+localparam LUMI_STATUS         = 8'h04; // device status
+localparam LUMI_TXMODE         = 8'h10; // tx operating mode
+localparam LUMI_RXMODE         = 8'h14; // rx operating mode
+localparam LUMI_CRDTINIT       = 8'h20; // Credit init value
+localparam LUMI_CRDTINTRVL     = 8'h24; // Credir update interval
+localparam LUMI_REQCRDTNAVAIL  = 8'h30; // Req credit not available
+localparam LUMI_RESPCRDTNAVAIL = 8'h34; // Resp credit not available
+localparam LUMI_REQCRDTAVAIL   = 8'h38; // Req credit available
+localparam LUMI_RESPCRDTAVAIL  = 8'h3C; // Resp credit available

--- a/umi/lumi/rtl/lumi_regs.v
+++ b/umi/lumi/rtl/lumi_regs.v
@@ -73,7 +73,11 @@ module lumi_regs
     output [15:0]   csr_txcrdt_intrvl,
     output [15:0]   csr_rxcrdt_req_init,
     output [15:0]   csr_rxcrdt_resp_init,
-    input [31:0]    csr_txcrdt_status
+    // performance counters
+    input [31:0]    csr_req_txcrdt_navail,
+    input [31:0]    csr_resp_txcrdt_navail,
+    input [31:0]    csr_req_txcrdt_avail,
+    input [31:0]    csr_resp_txcrdt_avail
     );
 
 `include "lumi_regmap.vh"
@@ -300,13 +304,16 @@ module lumi_regs
      else
        if (reg_read)
          case (reg_addr[7:2])
-           LUMI_CTRL[7:2]      : reg_rddata[RW-1:0] <= ctrl_reg[RW-1:0];
-           LUMI_STATUS[7:2]    : reg_rddata[RW-1:0] <= status_reg[RW-1:0];
-           LUMI_TXMODE[7:2]    : reg_rddata[RW-1:0] <= txmode_reg[RW-1:0];
-           LUMI_RXMODE[7:2]    : reg_rddata[RW-1:0] <= rxmode_reg[RW-1:0];
-           LUMI_CRDTINIT[7:2]  : reg_rddata[RW-1:0] <= {{RW-32{1'b0}},rxcrdt_init_reg[31:0]};
-           LUMI_CRDTINTRVL[7:2]: reg_rddata[RW-1:0] <= {{RW-16{1'b0}},txcrdt_intrvl_reg[15:0]};
-           LUMI_CRDTSTAT[7:2]  : reg_rddata[RW-1:0] <= {{RW-32{1'b0}},csr_txcrdt_status[31:0]};
+           LUMI_CTRL[7:2]          : reg_rddata[RW-1:0] <= ctrl_reg[RW-1:0];
+           LUMI_STATUS[7:2]        : reg_rddata[RW-1:0] <= status_reg[RW-1:0];
+           LUMI_TXMODE[7:2]        : reg_rddata[RW-1:0] <= txmode_reg[RW-1:0];
+           LUMI_RXMODE[7:2]        : reg_rddata[RW-1:0] <= rxmode_reg[RW-1:0];
+           LUMI_CRDTINIT[7:2]      : reg_rddata[RW-1:0] <= {{RW-32{1'b0}},rxcrdt_init_reg[31:0]};
+           LUMI_CRDTINTRVL[7:2]    : reg_rddata[RW-1:0] <= {{RW-16{1'b0}},txcrdt_intrvl_reg[15:0]};
+           LUMI_REQCRDTNAVAIL[7:2] : reg_rddata[RW-1:0] <= {{RW-32{1'b0}},csr_req_txcrdt_navail[31:0]};
+           LUMI_RESPCRDTNAVAIL[7:2]: reg_rddata[RW-1:0] <= {{RW-32{1'b0}},csr_resp_txcrdt_navail[31:0]};
+           LUMI_REQCRDTAVAIL[7:2]  : reg_rddata[RW-1:0] <= {{RW-32{1'b0}},csr_req_txcrdt_avail[31:0]};
+           LUMI_RESPCRDTAVAIL[7:2] : reg_rddata[RW-1:0] <= {{RW-32{1'b0}},csr_resp_txcrdt_avail[31:0]};
            default:
              reg_rddata[RW-1:0] <= 'b0;
          endcase

--- a/umi/lumi/tests/conftest.py
+++ b/umi/lumi/tests/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+from switchboard import SbDut
+from umi import lumi
+from fasteners import InterProcessLock
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "lumi_dut" in getattr(item, "fixturenames", ()):
+            item.add_marker("switchboard")
+            pass
+
+
+@pytest.fixture
+def build_dir(pytestconfig):
+    return pytestconfig.cache.mkdir('lumi_build')
+
+
+@pytest.fixture
+def lumi_dut(build_dir, request):
+    dut = SbDut('testbench', default_main=True, trace=False)
+
+    dut.use(lumi)
+
+    # Add testbench
+    dut.input('lumi/testbench/testbench_lumi.sv', package='umi')
+
+    # Verilator configuration
+    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', 'lumi/testbench/config.vlt',
+            package='umi')
+
+    # Build simulator
+    dut.set('option', 'builddir', build_dir / lumi.__name__)
+    with InterProcessLock(build_dir / f'{lumi.__name__}.lock'):
+        # ensure build only happens once
+        # https://github.com/pytest-dev/pytest-xdist/blob/v3.6.1/docs/how-to.rst#making-session-scoped-fixtures-execute-only-once
+        dut.build(fast=True)
+
+    yield dut
+
+    dut.terminate()
+
+
+@pytest.fixture(params=("2d", "3d"))
+def chip_topo(request):
+    return request.param

--- a/umi/lumi/tests/test_lumi_rnd.py
+++ b/umi/lumi/tests/test_lumi_rnd.py
@@ -5,68 +5,35 @@
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 import time
-import random
 import numpy as np
-from argparse import ArgumentParser
-from switchboard import SbDut, UmiTxRx, delete_queue
-from umi import lumi
+from switchboard import UmiTxRx
+import pytest
 
 
-def build_testbench(topo="2d", trace=False):
-    dut = SbDut('testbench', trace=trace, trace_type='fst', default_main=True)
+def test_lumi_rnd(lumi_dut, chip_topo, random_seed, sb_umi_valid_mode, sb_umi_ready_mode):
 
-    # Set up inputs
-    dut.input('lumi/testbench/testbench_lumi.sv', package='umi')
-    if topo == '2d':
-        print("### Running 2D topology ###")
-    elif topo == '3d':
-        print("### Running 3D topology ###")
-    else:
-        raise ValueError('Invalid topology')
+    np.random.seed(random_seed)
 
-    dut.use(lumi)
-
-    # Verilator configuration
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', 'lumi/testbench/config.vlt', package='umi')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '--prof-cfuncs')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-CFLAGS')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-DVL_DEBUG')
-    dut.add('tool', 'verilator', 'task', 'compile', 'option', '-Wall')
-
-    # Build simulator
-    dut.build()
-
-    return dut
-
-
-def main(topo="2d", vldmode="2", rdymode="2", trace=False,
-         host2dut="host2dut_0.q", dut2host="dut2host_0.q", sb2dut="sb2dut_0.q", dut2sb="dut2sb_0.q"):
-    # clean up old queues if present
-    for q in [host2dut, dut2host, sb2dut, dut2sb]:
-        delete_queue(q)
-
-    dut = build_testbench(topo, trace)
-
-    hostdly = random.randrange(500)
-    devdly = random.randrange(500)
+    hostdly = np.random.randint(500)
+    devdly = np.random.randint(500)
+    topo = chip_topo
 
     # launch the simulation
-    dut.simulate(
+    lumi_dut.simulate(
         plusargs=[
-            ('valid_mode', vldmode),
-            ('ready_mode', rdymode),
+            ('valid_mode', sb_umi_valid_mode),
+            ('ready_mode', sb_umi_ready_mode),
             ('hostdly', hostdly),
             ('devdly', devdly)
-        ],
-        trace=trace
+        ]
     )
 
     # instantiate TX and RX queues.  note that these can be instantiated without
     # specifying a URI, in which case the URI can be specified later via the
     # "init" method
 
-    sb = UmiTxRx(sb2dut, dut2sb)
-    host = UmiTxRx(host2dut, dut2host)
+    sb = UmiTxRx("sb2dut_0.q", "dut2sb_0.q", fresh=True)
+    host = UmiTxRx("host2dut_0.q", "dut2host_0.q", fresh=True)
 
     print("### Side Band loc reset ###")
     sb.write(0x7000000C, np.uint32(0x00000000), posted=True)
@@ -164,8 +131,8 @@ def main(topo="2d", vldmode="2", rdymode="2", trace=False,
     for count in range(100):
         # length should not cross the DW boundary - umi_mem_agent limitation
         length = np.random.randint(0, 511)
-        dst_addr = 32*random.randrange(2**(10-5)-1)  # sb limitation - should align to bus width
-        src_addr = 32*random.randrange(2**(10-5)-1)
+        dst_addr = 32*np.random.randint(2**(10-5))  # sb limitation - should align to bus width
+        src_addr = 32*np.random.randint(2**(10-5))
         data8 = np.random.randint(0, 255, size=length, dtype=np.uint8)
         print(f"umi writing {length+1} bytes to addr 0x{dst_addr:08x}")
         host.write(dst_addr, data8, srcaddr=src_addr)
@@ -177,19 +144,40 @@ def main(topo="2d", vldmode="2", rdymode="2", trace=False,
             print(f"Actual: {val8}")
             assert (val8 == data8).all()
 
+    print("### Read loc Tx req credit unavailable ###")
+    val32 = sb.read(0x70000030, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read loc Tx resp credit unavailable ###")
+    val32 = sb.read(0x70000034, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read loc Tx req credit available ###")
+    val32 = sb.read(0x70000038, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read loc Tx resp credit available ###")
+    val32 = sb.read(0x7000003C, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read rmt Tx req credit unavailable ###")
+    val32 = sb.read(0x60000030, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read rmt Tx resp credit unavailable ###")
+    val32 = sb.read(0x60000034, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read rmt Tx req credit available ###")
+    val32 = sb.read(0x60000038, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
+    print("### Read rmt Tx resp credit available ###")
+    val32 = sb.read(0x6000003C, np.uint32)
+    print(f"Read: 0x{val32:08x}")
+
     print("### TEST PASS ###")
 
 
 if __name__ == '__main__':
-    parser = ArgumentParser()
-    parser.add_argument('--trace', action='store_true', default=False,
-                        help="Enable waveform tracing")
-    parser.add_argument('--topo', default='2d')
-    parser.add_argument('--vldmode', default='2')
-    parser.add_argument('--rdymode', default='2')
-    args = parser.parse_args()
-
-    main(topo=args.topo,
-         vldmode=args.vldmode,
-         rdymode=args.rdymode,
-         trace=args.trace)
+    pytest.main(['-s', '-q', __file__])

--- a/umi/sumi/tests/conftest.py
+++ b/umi/sumi/tests/conftest.py
@@ -1,10 +1,8 @@
 import pytest
 from switchboard import SbDut, UmiTxRx, random_umi_packet
-import os
 from pathlib import Path
 from umi import sumi
 from fasteners import InterProcessLock
-import multiprocessing
 import numpy as np
 
 
@@ -13,26 +11,6 @@ def pytest_collection_modifyitems(items):
         if "sumi_dut" in getattr(item, "fixturenames", ()):
             item.add_marker("switchboard")
             pass
-
-
-@pytest.fixture(autouse=True)
-def test_wrapper(tmp_path):
-    '''
-    Fixture that automatically runs each test in a test-specific temporary
-    directory to avoid clutter.
-    '''
-    try:
-        multiprocessing.set_start_method('fork')
-    except RuntimeError:
-        pass
-
-    topdir = os.getcwd()
-    os.chdir(tmp_path)
-
-    # Run the test.
-    yield
-
-    os.chdir(topdir)
 
 
 @pytest.fixture
@@ -69,22 +47,6 @@ def sumi_dut(build_dir, request):
     yield dut
 
     dut.terminate()
-
-
-def pytest_addoption(parser):
-    parser.addoption("--seed", type=int, action="store", help="Provide a fixed seed")
-
-
-@pytest.fixture
-def random_seed(request):
-    fixed_seed = request.config.getoption("--seed")
-    if fixed_seed is not None:
-        test_seed = fixed_seed
-    else:
-        test_seed = os.getpid()
-    print(f'Random seed used: {test_seed}')
-    yield test_seed
-    print(f'Random seed used: {test_seed}')
 
 
 @pytest.fixture


### PR DESCRIPTION
- Minor fixes to LUMI RTL
- Add LUMI performance counters to count cycles when credits are/aren't available
- Make tests compatible with pytest
- Pull reusable pytest fixtures out to the umi parent directory