### PR TITLE
Fixed Verilator pin missing warning in umi_fifoflex.v

### DIFF
--- a/umi/sumi/umi_fifoflex/rtl/umi_fifoflex.v
+++ b/umi/sumi/umi_fifoflex/rtl/umi_fifoflex.v
@@ -578,22 +578,24 @@ module umi_fifoflex
         la_asyncfifo  #(.DW(CW+AW+AW+ODW),
                         .DEPTH(DEPTH))
         fifo  (// Outputs
-               .wr_full      (fifo_full_raw),
-               .rd_dout      (fifo_dout[ODW+AW+AW+CW-1:0]),
-               .rd_empty     (fifo_empty_raw),
+               .wr_full         (fifo_full_raw),
+               // TODO: Should almost full signal be exposed?
+               .wr_almost_full  (),
+               .rd_dout         (fifo_dout[ODW+AW+AW+CW-1:0]),
+               .rd_empty        (fifo_empty_raw),
                // Inputs
-               .wr_clk       (umi_in_clk),
-               .wr_nreset    (umi_in_nreset),
-               .wr_din       (fifo_din[ODW+AW+AW+CW-1:0]),
-               .wr_en        (fifo_write),
-               .wr_chaosmode (chaosmode),
-               .rd_clk       (umi_out_clk),
-               .rd_nreset    (umi_out_nreset),
-               .rd_en        (fifo_read),
-               .vss          (vss),
-               .vdd          (vdd),
-               .ctrl         (1'b0),
-               .test         (1'b0));
+               .wr_clk          (umi_in_clk),
+               .wr_nreset       (umi_in_nreset),
+               .wr_din          (fifo_din[ODW+AW+AW+CW-1:0]),
+               .wr_en           (fifo_write),
+               .wr_chaosmode    (chaosmode),
+               .rd_clk          (umi_out_clk),
+               .rd_nreset       (umi_out_nreset),
+               .rd_en           (fifo_read),
+               .vss             (vss),
+               .vdd             (vdd),
+               .ctrl            (1'b0),
+               .test            (1'b0));
      end
    else if (|DEPTH)
      begin

--- a/umi/sumi/umi_fifoflex/umi_fifoflex.py
+++ b/umi/sumi/umi_fifoflex/umi_fifoflex.py
@@ -1,7 +1,7 @@
 from umi.common import UMI
 from umi.sumi.umi_pack.umi_pack import Pack
 from umi.sumi.umi_unpack.umi_unpack import Unpack
-from lambdalib.ramlib import Syncfifo
+from lambdalib.ramlib import Syncfifo, Asyncfifo
 
 
 class FifoFlex(UMI):
@@ -10,7 +10,8 @@ class FifoFlex(UMI):
                          files=['rtl/umi_fifoflex.v'],
                          deps=[Pack(),
                                Unpack(),
-                               Syncfifo()])
+                               Syncfifo(),
+                               Asyncfifo()])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Maybe a longer discussion here on if we want to expose the fifo almost full signal to the top level of umi_fifoflex. If we did so it would make sense to add a fifo almost full signal to la_syncfifo. 