### PR TITLE
UMI2APB bug fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "cocotb-bus==0.3.0",
     "cocotbext-axi==0.1.28",
     "cocotbext-umi==0.0.3",
-    "cocotbext-apb==0.7.4"
+    "cocotbext-apb==0.11.0"
 ]
 
 [tool.check-wheel-contents]

--- a/tests/adapters/umi2apb/__init__.py
+++ b/tests/adapters/umi2apb/__init__.py
@@ -1,6 +1,0 @@
-# Import tests so cocotb can discover them
-from adapters.umi2apb.test_basic_WR import test_basic_WR  # noqa: F401
-from adapters.umi2apb.test_full_throughput import test_full_throughput  # noqa: F401
-from adapters.umi2apb.test_random_stimulus import test_random_stimulus  # noqa: F401
-from adapters.umi2apb.test_posted_write import test_posted_write  # noqa: F401
-from adapters.umi2apb.test_backpressure import test_backpressure  # noqa: F401

--- a/tests/adapters/umi2apb/env.py
+++ b/tests/adapters/umi2apb/env.py
@@ -2,23 +2,40 @@
 # and provides common functionality for the tests.
 
 from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles
+from cocotb.triggers import ClockCycles, Timer
 
 from cocotb_bus.scoreboard import Scoreboard
 from cocotbext.apb import ApbBus, ApbSlave, MemoryRegion
 
-from cocotblib.umi.drivers.sumi_driver import SumiDriver
-from cocotblib.umi.monitors.sumi_monitor import SumiMonitor
-from cocotblib.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
-from cocotblib.common import drive_reset
+from cocotbext.umi.drivers.sumi_driver import SumiDriver
+from cocotbext.umi.monitors.sumi_monitor import SumiMonitor
+from cocotbext.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+
+
+async def do_reset(reset, time_ns: int, active_level: bool = False):
+    """Drive an asynchronous reset pulse on *reset*."""
+    reset.value = not active_level
+    await Timer(1, unit="step")
+    reset.value = active_level
+    await Timer(time_ns, "ns")
+    reset.value = not active_level
+    await Timer(1, unit="step")
 
 
 # Creates the umi2apb test environment
 class UMI2APBEnv:
-    def __init__(self, dut, clk_period_ns=10, mem_size=2**16):
+    def __init__(
+        self,
+        dut,
+        clk_period_ns=10,
+        mem_size=2**16,
+        umi_valid_gen=None,
+        backpressure_on_apb=True
+    ):
         self.dut = dut
         self.clk_period_ns = clk_period_ns
         self.mem_size = mem_size
+        self.umi_valid_gen = umi_valid_gen
 
         self.data_width = int(dut.RW.value)  # default of 64
         self.addr_width = int(dut.AW.value)  # default of 64
@@ -29,22 +46,20 @@ class UMI2APBEnv:
         self.clk = dut.apb_pclk
         self.nreset = dut.apb_nreset
 
-        self._build()
-
-    def _build(self):
-        dut = self.dut
-
         # Instantiates UMI driver
         self.sumi_driver = SumiDriver(
             entity=dut,
             name="udev_req",
             clock=self.clk,
-            bus_separator="_"
+            bus_separator="_",
+            valid_generator=self.umi_valid_gen,
         )
 
         # Instantiates APB slave and memory region
         apb_bus = ApbBus.from_prefix(dut, "apb")
         self.apb_slave = ApbSlave(apb_bus, self.clk, self.nreset)
+        if backpressure_on_apb:
+            self.apb_slave.enable_backpressure()
         self.region = MemoryRegion(self.mem_size)
         self.apb_slave.target = self.region
 
@@ -62,21 +77,9 @@ class UMI2APBEnv:
 
     # Prerequisites for starting tests
     async def start(self):
+        await do_reset(self.nreset, self.clk_period_ns)
         Clock(self.clk, self.clk_period_ns, unit="ns").start()
-        await drive_reset(self.nreset, self.clk_period_ns)
-        self.dut.udev_resp_ready.value = 1
-
-    # Waits for umi responses
-    async def wait_for_responses(self, max_cycles):
-        cycles = 0
-        while self.expected_responses:
-            await ClockCycles(self.clk, 1)
-            cycles += 1
-            if cycles > max_cycles:
-                raise TimeoutError(
-                    f"Timeout waiting for responses "
-                    f"({len(self.expected_responses)} remaining)"
-                )
+        await ClockCycles(self.clk, 10)
 
 
 # Creates an ideal umi write response

--- a/tests/adapters/umi2apb/test_backpressure.py
+++ b/tests/adapters/umi2apb/test_backpressure.py
@@ -4,11 +4,11 @@ import cocotb
 from cocotb.handle import SimHandleBase
 from cocotb.triggers import ClockCycles
 
-from cocotblib.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
-from adapters.umi2apb.env import UMI2APBEnv, create_expected_write_response
+from cocotbext.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+from env import UMI2APBEnv, create_expected_write_response
 
 
-@cocotb.test(timeout_time=50, timeout_unit="ms")
+@cocotb.test(timeout_time=1, timeout_unit="ms")
 async def test_backpressure(dut: SimHandleBase):
     """
     Test response backpressure handling:
@@ -54,7 +54,7 @@ async def test_backpressure(dut: SimHandleBase):
     env.sumi_driver.append(write_txn)
     print(f"Sent write: addr=0x{test_addr:x}, data=0x{test_data:08x}")
 
-    await ClockCycles(env.clk, 20)
+    await ClockCycles(env.clk, 200)
 
     # Verify response is being held
     assert dut.udev_resp_valid.value == 1, "Response should be valid"
@@ -65,7 +65,7 @@ async def test_backpressure(dut: SimHandleBase):
     dut.udev_resp_ready.value = 1
     print("Re-enabled udev_resp_ready")
 
-    await env.wait_for_responses(max_cycles=10)
+    await ClockCycles(env.clk, 100)
 
     # Verify mem was written correctly
     mem_data = await env.region.read(test_addr, env.data_size)

--- a/tests/adapters/umi2apb/test_basic_WR.py
+++ b/tests/adapters/umi2apb/test_basic_WR.py
@@ -2,9 +2,12 @@ import math
 import cocotb
 
 from cocotb.handle import SimHandleBase
+from cocotb.triggers import ClockCycles
+from cocotb_bus.drivers import BitDriver
 
-from cocotblib.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
-from adapters.umi2apb.env import UMI2APBEnv, create_expected_write_response
+from cocotbext.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+from cocotbext.umi.utils.generators import random_toggle_generator
+from env import UMI2APBEnv, create_expected_write_response
 
 
 @cocotb.test(timeout_time=50, timeout_unit="ms")
@@ -20,6 +23,10 @@ async def test_basic_WR(dut: SimHandleBase):
     # Grab shared test environment
     env = UMI2APBEnv(dut)
     await env.start()
+
+    BitDriver(signal=dut.udev_resp_ready, clk=env.clk).start(
+        generator=random_toggle_generator()
+    )
 
     umi_size = int(math.log2(env.data_size))
     test_addr = 0x100
@@ -47,10 +54,8 @@ async def test_basic_WR(dut: SimHandleBase):
         )
     )
 
-    env.sumi_driver.append(write_txn)
-
-    # Wait for write response
-    await env.wait_for_responses(max_cycles=100)
+    await env.sumi_driver.send(write_txn)
+    await ClockCycles(env.clk, 20)
 
     # Verify APB memory contents
     mem_data = await env.region.read(test_addr, env.data_size)
@@ -89,10 +94,13 @@ async def test_basic_WR(dut: SimHandleBase):
     )
 
     env.expected_responses.append(expected_read_resp)
-    env.sumi_driver.append(read_txn)
+    await env.sumi_driver.send(read_txn)
 
-    # Wait for read response
-    await env.wait_for_responses(max_cycles=100)
+    # Wait for scoreboard to consume all expected outputs
+    while len(env.expected_responses) != 0:
+        await ClockCycles(env.clk, 1)
+
+    await ClockCycles(env.clk, 10)
 
     print("Read response verified by scoreboard")
 

--- a/tests/adapters/umi2apb/test_full_throughput.py
+++ b/tests/adapters/umi2apb/test_full_throughput.py
@@ -1,8 +1,10 @@
 import math
 import cocotb
 
-from adapters.umi2apb.env import UMI2APBEnv
-from cocotblib.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+from cocotb.triggers import Event, Combine, ClockCycles
+
+from env import UMI2APBEnv
+from cocotbext.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
 
 
 @cocotb.test(timeout_time=50, timeout_unit="ms")
@@ -16,6 +18,9 @@ async def test_full_throughput(dut):
     env = UMI2APBEnv(dut)
     await env.start()
 
+    # Always ready to accept responses
+    dut.udev_resp_ready.value = 1
+
     data_size = env.data_size
     addr_width = env.addr_width
     umi_size = int(math.log2(data_size))
@@ -24,6 +29,7 @@ async def test_full_throughput(dut):
 
     print("=== Back-to-Back Full Throughput Test ===")
 
+    send_events = []
     for i in range(num_transactions):
         txn_size = i % (umi_size + 1)
         txn_bytes = 1 << txn_size
@@ -81,10 +87,15 @@ async def test_full_throughput(dut):
             )
 
         env.expected_responses.append(expected_resp)
-        env.sumi_driver.append(txn)
+        evt = Event()
+        env.sumi_driver.append(txn, event=evt)
+        send_events.append(evt)
 
     # Wait for all responses
-    await env.wait_for_responses(max_cycles=num_transactions * 50)
+    await Combine(*(e.wait() for e in send_events))
+
+    await ClockCycles(env.clk, 100)
 
     print(f" All {num_transactions} back-to-back transactions completed successfully!")
+
     raise env.scoreboard.result

--- a/tests/adapters/umi2apb/test_posted_write.py
+++ b/tests/adapters/umi2apb/test_posted_write.py
@@ -2,10 +2,12 @@ import math
 import cocotb
 
 from cocotb.handle import SimHandleBase
+from cocotb_bus.drivers import BitDriver
 from cocotb.triggers import ClockCycles
 
-from cocotblib.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
-from adapters.umi2apb.env import UMI2APBEnv
+from cocotbext.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+from cocotbext.umi.utils.generators import random_toggle_generator
+from env import UMI2APBEnv
 
 
 @cocotb.test(timeout_time=50, timeout_unit="ms")
@@ -18,6 +20,10 @@ async def test_posted_write(dut: SimHandleBase):
 
     env = UMI2APBEnv(dut)
     await env.start()
+
+    BitDriver(signal=dut.udev_resp_ready, clk=env.clk).start(
+        generator=random_toggle_generator()
+    )
 
     umi_size = int(math.log2(env.data_size))
 

--- a/tests/adapters/umi2apb/test_random_stimulus.py
+++ b/tests/adapters/umi2apb/test_random_stimulus.py
@@ -1,14 +1,32 @@
+import os
 import math
-import cocotb
-from random import randint, randbytes
-from cocotb.triggers import ClockCycles
+from random import randint, randbytes, choices
 
-from adapters.umi2apb.env import UMI2APBEnv, create_expected_write_response
-from cocotblib.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+import cocotb
+from cocotb.triggers import Event, Combine, ClockCycles
+
+from cocotb_bus.drivers import BitDriver
+
+from env import UMI2APBEnv, create_expected_write_response
+from cocotbext.umi.sumi import SumiTransaction, SumiCmdType, SumiCmd
+from cocotbext.umi.utils.generators import (
+    random_toggle_generator,
+    wave_generator
+)
 
 
 @cocotb.test(timeout_time=50, timeout_unit="ms")
-async def test_random_stimulus(dut):
+@cocotb.parametrize(
+    valid_gen=[None, random_toggle_generator(), wave_generator()],
+    ready_gen=[None, random_toggle_generator(), wave_generator()],
+    test_n_transactions=[int(512 * float(os.getenv("RAND_TEST_LEN_SCALER", default=1)))],
+)
+async def test_random_stimulus(
+    dut,
+    valid_gen=None,
+    ready_gen=None,
+    test_n_transactions=512
+):
     """
     Randomized read/write stimulus.
 
@@ -17,42 +35,55 @@ async def test_random_stimulus(dut):
     - Memory model checked at the end
     """
     # Grab shared test environment
-    env = UMI2APBEnv(dut)
+    env = UMI2APBEnv(dut, umi_valid_gen=valid_gen)
     await env.start()
+
+    if ready_gen is None:
+        dut.udev_resp_ready.value = 1
+    else:
+        BitDriver(signal=dut.udev_resp_ready, clk=env.clk).start(generator=ready_gen)
 
     data_size = env.data_size
     addr_width = env.addr_width
     umi_size = int(math.log2(data_size))
 
     mem_size = 2**16
-    num_random_transactions = 512
-    read_probability = 0.5
 
-    print(f"=== Randomized Test: {num_random_transactions} transactions ===")
+    print(f"=== Randomized Test: {test_n_transactions} transactions ===")
 
     # Ideal memory model for writes/reads
     memory_model = {}
 
-    for i in range(num_random_transactions):
+    send_events = []
+
+    for i in range(test_n_transactions):
         txn_bytes = env.data_size
         max_addr = (mem_size - txn_bytes) // txn_bytes
 
         # Randomized address and command type
         addr = randint(0, max_addr) * txn_bytes
-        is_read = randint(0, 99) < (read_probability * 100)
 
-        if is_read:
-            txn = SumiTransaction(
-                cmd=SumiCmd.from_fields(
-                    cmd_type=int(SumiCmdType.UMI_REQ_READ),
-                    size=umi_size,
-                    len=0,
-                ),
-                da=addr,
-                sa=0x0,
-                data=bytearray(txn_bytes),
-            )
+        cmd_type = choices(
+            population=[
+                SumiCmdType.UMI_REQ_READ,
+                SumiCmdType.UMI_REQ_WRITE,
+                SumiCmdType.UMI_REQ_POSTED
+            ],
+            weights=[0.4, 0.3, 0.3],
+        )[0]
 
+        data = randbytes(txn_bytes)
+        txn = SumiTransaction(
+            cmd=SumiCmd.from_fields(
+                cmd_type=int(cmd_type),
+                size=umi_size,
+                len=0,
+            ),
+            da=addr,
+            sa=0x0,
+            data=data,
+        )
+        if cmd_type == SumiCmdType.UMI_REQ_READ:
             expected_data = memory_model.get(addr, bytearray(txn_bytes))
             expected_resp = SumiTransaction(
                 cmd=SumiCmd.from_fields(
@@ -65,35 +96,21 @@ async def test_random_stimulus(dut):
                 data=expected_data,
                 addr_width=addr_width,
             )
-
             env.expected_responses.append(expected_resp)
-
-        else:
-            data = randbytes(txn_bytes)
+        elif cmd_type == SumiCmdType.UMI_REQ_WRITE:
+            memory_model[addr] = data
+            env.expected_responses.append(create_expected_write_response(txn, txn_bytes, addr_width))
+        elif cmd_type == SumiCmdType.UMI_REQ_POSTED:
             memory_model[addr] = data
 
-            txn = SumiTransaction(
-                cmd=SumiCmd.from_fields(
-                    cmd_type=int(SumiCmdType.UMI_REQ_WRITE),
-                    size=umi_size,
-                    len=0,
-                ),
-                da=addr,
-                sa=0x0,
-                data=data,
-            )
+        e = Event()
+        env.sumi_driver.append(txn, event=e)
+        send_events.append(e)
 
-            env.expected_responses.append(
-                create_expected_write_response(txn, txn_bytes, addr_width)
-            )
+    # Wait for all transactions to be sent
+    await Combine(*(e.wait() for e in send_events))
 
-        await env.sumi_driver.send(txn)
-
-        if (i + 1) % 100 == 0:
-            print(f"    Sent {i+1}/{num_random_transactions} transactions...")
-            await ClockCycles(env.clk, 1)
-
-    await env.wait_for_responses(max_cycles=num_random_transactions * 50)
+    await ClockCycles(env.clk, 100)
 
     # Memory verification
     num_verified = 0
@@ -106,7 +123,7 @@ async def test_random_stimulus(dut):
         num_verified += 1
 
     print("\n=== Test Statistics ===")
-    print(f"    Total transactions: {num_random_transactions}")
+    print(f"    Total transactions: {test_n_transactions}")
     print(f"    Unique addresses written: {len(memory_model)}")
     print(f"    Memory locations verified: {num_verified}")
     print("    All transactions completed")

--- a/tests/adapters/umi2apb/test_run.py
+++ b/tests/adapters/umi2apb/test_run.py
@@ -1,30 +1,38 @@
-# tests/adapters/umi2apb/run.py
-
 import pytest
-from siliconcompiler import Sim
 
-from umi.adapters import UMI2APB
-from cocotblib.common import run_cocotb
+from siliconcompiler import Design
+
+from umi.adapters.umi2apb.umi2apb import UMI2APB
 
 
-def run_umi2apb(simulator="verilator", waves=True):
-    project = Sim(UMI2APB())
-    project.add_fileset("rtl")
+class TbDesign(Design):
 
-    tests_failed = run_cocotb(
-        project=project,
-        test_module_name="adapters.umi2apb",
-        simulator_name=simulator,
-        timescale=("1ns", "1ps"),
-        build_args=["--report-unoptflat"] if simulator == "verilator" else [],
-        output_dir_name=f"umi2apb_{simulator}",
-        waves=waves,
+    def __init__(self):
+        super().__init__()
+
+        self.set_name("tb_umi2apb")
+
+        self.set_dataroot("tb_umi2apb", __file__)
+
+        with self.active_dataroot("tb_umi2apb"):
+            with self.active_fileset("testbench.cocotb"):
+                self.set_topmodule("umi2apb")
+                self.add_file("env.py", filetype="python")
+                self.add_file("test_basic_WR.py", filetype="python")
+                self.add_file("test_backpressure.py", filetype="python")
+                self.add_file("test_full_throughput.py", filetype="python")
+                self.add_file("test_posted_write.py", filetype="python")
+                self.add_file("test_random_stimulus.py", filetype="python")
+                self.add_depfileset(UMI2APB(), "rtl")
+
+
+@pytest.mark.cocotb
+@pytest.mark.parametrize("simulator", ["icarus", "verilator"])
+def test_umi2apb(simulator, output_wave=False):
+    from run_cocotb_sim import load_cocotb_test
+    load_cocotb_test(
+        design=TbDesign(),
+        simulator=simulator,
+        trace=output_wave,
+        seed=None
     )
-
-    assert tests_failed == 0
-
-
-@pytest.mark.sim
-@pytest.mark.parametrize("simulator", ["verilator"])
-def test_umi2apb(simulator):
-    run_umi2apb(simulator)

--- a/umi/__init__.py
+++ b/umi/__init__.py
@@ -3,7 +3,7 @@ from umi import lumi
 from umi import adapters
 from umi.common import Standard
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 __all__ = [
     "Standard",

--- a/umi/adapters/umi2apb/rtl/umi2apb.v
+++ b/umi/adapters/umi2apb/rtl/umi2apb.v
@@ -71,127 +71,117 @@ module umi2apb #(parameter AW = 64,        // UMI address width
     input             apb_pready,  // ready
     input [RW-1:0]    apb_prdata,  // read data
     input             apb_pslverr  // error
-    );
+);
 
-`include "umi_messages.vh"
+  `include "umi_messages.vh"
 
-   reg [CW-1:0]    udev_req_cmd_r;
-   reg [AW-1:0]    udev_req_dstaddr_r;
-   reg [AW-1:0]    udev_req_srcaddr_r;
-   reg [RW-1:0]    udev_req_data_r;
+  //####################################
+  // Registers
+  //####################################
+  reg [CW-1:0]    udev_req_cmd_r;
+  reg [AW-1:0]    udev_req_dstaddr_r;
+  reg [AW-1:0]    udev_req_srcaddr_r;
+  reg [RW-1:0]    udev_req_data_r;
 
-   wire            incoming_req;
-   wire            outgoing_resp;
-   wire            group_match;
+  reg [1:0]       pslverr_r;
+  reg [RW-1:0]    prdata_r;
 
-   wire [CW-1:0]   cmd_packet;
-   wire [4:0]      cmd_opcode;
-   wire            cmd_read;
-   wire            cmd_write;
-   wire            cmd_posted;
-   wire [1:0]      cmd_prot;
+  //####################################
+  // Wires
+  //####################################
+  wire            incoming_req;
+  wire            group_match;
 
+  wire [CW-1:0]   cmd_packet;
+  wire [4:0]      cmd_opcode;
+  wire            cmd_write;
+  wire            cmd_posted;
+  wire [1:0]      cmd_prot;
 
-   reg [1:0]       pslverr_r;
-   reg [RW-1:0]    prdata_r;
-   reg cmd_read_r;
+  wire            apb_bus_fire;
+  wire            capture_resp;
+  wire            op_read_resp;
 
-   //############################
-   //# UMI Request
-   //############################
+  //############################
+  //# UMI Request
+  //############################
 
-   generate
-      if (GRPAW != 0)
-        assign group_match = (udev_req_dstaddr[GRPOFFSET+:GRPAW]==GRPID[GRPAW-1:0]);
-      else
-        assign group_match = 1'b1;
-   endgenerate
+  generate
+    if (GRPAW != 0)
+      assign group_match = (udev_req_dstaddr[GRPOFFSET+:GRPAW]==GRPID[GRPAW-1:0]);
+    else
+      assign group_match = 1'b1;
+  endgenerate
 
-   assign incoming_req  = udev_req_valid & udev_req_ready & group_match;
+  assign incoming_req = udev_req_valid & udev_req_ready & group_match;
 
-   always @(posedge apb_pclk or negedge apb_nreset) begin
-      if (~apb_nreset) begin
-         udev_req_cmd_r     <= {CW{1'b0}};
-         udev_req_dstaddr_r <= {AW{1'b0}};
-         udev_req_srcaddr_r <= {AW{1'b0}};
-         udev_req_data_r    <= {RW{1'b0}};
-      end
-      else if (incoming_req) begin
-         udev_req_cmd_r     <= udev_req_cmd;
-         udev_req_dstaddr_r <= udev_req_dstaddr;
-         udev_req_srcaddr_r <= udev_req_srcaddr;
-         udev_req_data_r    <= udev_req_data[RW-1:0];
-         cmd_read_r   <= (udev_req_cmd[UMI_OPCODE_MSB:UMI_OPCODE_LSB] == UMI_REQ_READ);
-      end
-   end
+  always @(posedge apb_pclk)
+    if (incoming_req) begin
+      udev_req_cmd_r     <= udev_req_cmd;
+      udev_req_dstaddr_r <= udev_req_dstaddr;
+      udev_req_srcaddr_r <= udev_req_srcaddr;
+      udev_req_data_r    <= udev_req_data[RW-1:0];
+    end
 
-   assign cmd_packet = incoming_req ? udev_req_cmd : udev_req_cmd_r;
-   assign cmd_opcode = cmd_packet[UMI_OPCODE_MSB:UMI_OPCODE_LSB];
+  assign cmd_packet = incoming_req ? udev_req_cmd : udev_req_cmd_r;
+  assign cmd_opcode = cmd_packet[UMI_OPCODE_MSB:UMI_OPCODE_LSB];
+  assign cmd_prot   = cmd_packet[UMI_PROT_MSB:UMI_PROT_LSB];
 
-   assign cmd_read   = cmd_opcode==UMI_REQ_READ;
-   assign cmd_write  = cmd_opcode==UMI_REQ_WRITE;
-   assign cmd_posted = cmd_opcode==UMI_REQ_POSTED;
-   assign cmd_prot   = cmd_packet[UMI_PROT_MSB:UMI_PROT_LSB];
+  assign cmd_write  = cmd_opcode==UMI_REQ_WRITE;
+  assign cmd_posted = cmd_opcode==UMI_REQ_POSTED;
 
-   //############################
-   //# APB Mapping
-   //############################
+  //############################
+  //# APB Mapping
+  //############################
 
-   assign apb_paddr   = incoming_req ? udev_req_dstaddr[RAW-1:0] :
-                                       udev_req_dstaddr_r[RAW-1:0];
+  assign apb_psel    = incoming_req | apb_penable;
+  assign apb_pwrite  = cmd_write | cmd_posted;
+  assign apb_pprot   = {1'b0, cmd_prot[1:0]};
+  assign apb_pstrb   = {(RW/8){1'b1}}; // TODO: Support strobe
 
-   assign apb_pprot   = {1'b0, cmd_prot[1:0]};
-   assign apb_pwrite  = cmd_write | cmd_posted;
-   assign apb_pwdata  = incoming_req ? udev_req_data[RW-1:0] : udev_req_data_r[RW-1:0];
-   assign apb_pstrb   = {(RW/8){1'b1}}; // TODO: Support strobe
-   assign apb_psel    = incoming_req | apb_penable;
+  assign apb_paddr   = incoming_req ? udev_req_dstaddr[RAW-1:0] : udev_req_dstaddr_r[RAW-1:0];
+  assign apb_pwdata  = incoming_req ? udev_req_data[RW-1:0] : udev_req_data_r[RW-1:0];
 
-   always @(posedge apb_pclk or negedge apb_nreset)
-     if (~apb_nreset)
-       apb_penable <= 1'b0;
-     else if (incoming_req)
-       apb_penable <= 1'b1;
-     else if (apb_pready)
-       apb_penable <= 1'b0;
+  always @(posedge apb_pclk or negedge apb_nreset)
+    if (~apb_nreset)
+      apb_penable <= 1'b0;
+    else if (incoming_req)
+      apb_penable <= 1'b1;
+    else if (apb_pready)
+      apb_penable <= 1'b0;
 
-   assign udev_req_ready = ~apb_penable;
+  assign udev_req_ready = ~apb_penable & ~udev_resp_valid;
 
-   //############################
-   //# UMI Response
-   //############################
+  //############################
+  //# UMI Response
+  //############################
 
-   assign outgoing_resp = (udev_resp_valid & udev_resp_ready) |
-                          (cmd_posted & apb_penable & apb_pready);
+  assign apb_bus_fire = apb_psel & apb_penable & apb_pready;
+  assign capture_resp = apb_bus_fire & ~cmd_posted;
 
-   always @(posedge apb_pclk or negedge apb_nreset)
-     if (~apb_nreset)
-       udev_resp_valid <= 1'b0;
-     else if (apb_penable & apb_pready & ~cmd_posted)
-       udev_resp_valid <= 1'b1;
-     else if (outgoing_resp)
-       udev_resp_valid <= 1'b0;
+  always @(posedge apb_pclk or negedge apb_nreset)
+    if (~apb_nreset)
+      udev_resp_valid <= 1'b0;
+    else if (capture_resp)
+      udev_resp_valid <= 1'b1;
+    else if (udev_resp_ready)
+      udev_resp_valid <= 1'b0;
 
-   always @(posedge apb_pclk or negedge apb_nreset)
-     if (~apb_nreset)
-       prdata_r <= 'b0;
-     else if (apb_penable & apb_pready)
-       prdata_r <= apb_prdata;
+  always @(posedge apb_pclk)
+    if (capture_resp) begin
+      prdata_r <= apb_prdata;
+      pslverr_r <= {apb_pslverr, 1'b0};
+    end
 
-   always @(posedge apb_pclk or negedge apb_nreset)
-     if (~apb_nreset)
-       pslverr_r <= 'b0;
-     else if (apb_penable & apb_pready)
-       pslverr_r <= {apb_pslverr, 1'b0};
+  assign op_read_resp = (udev_req_cmd_r[UMI_OPCODE_MSB:UMI_OPCODE_LSB] == UMI_REQ_READ);
 
-   assign udev_resp_cmd[UMI_OPCODE_MSB:UMI_OPCODE_LSB] = cmd_read_r ? UMI_RESP_READ : UMI_RESP_WRITE;
-   assign udev_resp_cmd[UMI_EX_BIT:UMI_SIZE_LSB]       = udev_req_cmd_r[UMI_EX_BIT:UMI_SIZE_LSB];
-   assign udev_resp_cmd[UMI_USER_MSB:UMI_USER_LSB]     = pslverr_r[1:0];
-   assign udev_resp_cmd[UMI_HOSTID_MSB:UMI_HOSTID_LSB] = udev_req_cmd_r[UMI_HOSTID_MSB:UMI_HOSTID_LSB];
+  assign udev_resp_cmd[UMI_OPCODE_MSB:UMI_OPCODE_LSB] = op_read_resp ? UMI_RESP_READ : UMI_RESP_WRITE;
+  assign udev_resp_cmd[UMI_EX_BIT:UMI_SIZE_LSB]       = udev_req_cmd_r[UMI_EX_BIT:UMI_SIZE_LSB];
+  assign udev_resp_cmd[UMI_USER_MSB:UMI_USER_LSB]     = pslverr_r[1:0];
+  assign udev_resp_cmd[UMI_HOSTID_MSB:UMI_HOSTID_LSB] = udev_req_cmd_r[UMI_HOSTID_MSB:UMI_HOSTID_LSB];
 
-   assign udev_resp_dstaddr[AW-1:0] = udev_req_srcaddr_r[AW-1:0];
-
-   assign udev_resp_srcaddr[AW-1:0] = udev_req_dstaddr_r[AW-1:0];
-
-   assign udev_resp_data[DW-1:0]    = {{(DW-RW){1'b0}}, prdata_r[RW-1:0]};
+  assign udev_resp_dstaddr[AW-1:0] = udev_req_srcaddr_r[AW-1:0];
+  assign udev_resp_srcaddr[AW-1:0] = udev_req_dstaddr_r[AW-1:0];
+  assign udev_resp_data[DW-1:0]    = {{(DW-RW){1'b0}}, prdata_r[RW-1:0]};
 
 endmodule


### PR DESCRIPTION
udev_resp channel did not apply back pressure to udev_req. The resulting behavior is that while udev_resp_ready is low new udev_req transaction can come through and overwrite the currently vaild udev_req data payload.
Reworked test to catch this bug and then fixed the RTL. 

Also removed unnecessary resets on payload registers. 