### PR TITLE
UMI Mux fix

### DIFF
--- a/tests/sumi/umi_mux/test_umi_mux.py
+++ b/tests/sumi/umi_mux/test_umi_mux.py
@@ -1,6 +1,6 @@
 import os
+import copy
 import random
-from pathlib import Path
 import pytest
 
 from siliconcompiler import Design
@@ -8,7 +8,7 @@ from umi.sumi.umi_mux.umi_mux import Mux
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles, Timer
+from cocotb.triggers import ClockCycles, RisingEdge, Timer
 
 from cocotb_bus.drivers import BitDriver
 from cocotbext.umi.sumi import SumiCmd, SumiCmdType, SumiTransaction
@@ -21,12 +21,21 @@ from cocotbext.umi.utils.generators import (
 )
 
 
+async def drive_reset(reset, time_ns=50):
+    reset.value = 1
+    await Timer(1, unit="step")
+    reset.value = 0
+    await Timer(time_ns, unit="ns")
+    reset.value = 1
+    await Timer(1, unit="step")
+
+
 @cocotb.test(timeout_time=20, timeout_unit="us")
 @cocotb.parametrize(
     input_valid_gen=[None, random_toggle_generator(), wave_generator()],
     output_ready_gen=[None, random_toggle_generator(), wave_generator()],
     test_n_transactions=[int(100 * float(os.getenv("RAND_TEST_LEN_SCALER", default=1)))],
-    arbmode=[0, 1]
+    arbmode=[0, 2]
 )
 async def mux_general_test(
     dut,
@@ -75,12 +84,7 @@ async def mux_general_test(
         BitDriver(signal=dut.umi_out_ready, clk=dut.clk).start(generator=output_ready_gen)
 
     # Reset sequence (active-low reset)
-    dut.nreset.value = 1
-    await Timer(1, unit="step")
-    dut.nreset.value = 0
-    await Timer(10, unit="ns")
-    dut.nreset.value = 1
-    await Timer(10, unit="ns")
+    await drive_reset(reset=dut.nreset, time_ns=10)
 
     # Start clock
     Clock(dut.clk, 1, unit="ns").start()
@@ -126,6 +130,106 @@ async def mux_general_test(
         assert expected == actual
 
 
+@cocotb.test(timeout_time=1, timeout_unit="us")
+async def mux_priority_test(dut):
+
+    umi_inputs = int(dut.umi_mux_i.N.value)
+    data_size = int(dut.DW.value)//8
+    aw = int(dut.AW.value)
+
+    dut.clk.value = 0
+    dut.nreset.value = 0
+
+    dut.arbmode.value = 0
+    dut.arbmask.value = 0
+
+    dut.umi_out_ready.value = 0
+
+    ####################################
+    # Create UMI Input Drivers
+    ####################################
+    umi_drivers = [
+        SumiDriver(
+            entity=dut,
+            name=f"umi_in{i}",
+            clock=dut.clk
+        )
+        for i in range(umi_inputs)
+    ]
+
+    def rand_transaction() -> SumiTransaction:
+        # Create random transactions
+        return SumiTransaction(
+            cmd=SumiCmd.from_fields(
+                cmd_type=int(SumiCmdType.UMI_REQ_WRITE),
+                size=1,
+                len=data_size
+            ),
+            addr_width=aw,
+            da=random.randint(0, (1 << aw) - 1),
+            sa=random.randint(0, (1 << aw) - 1),
+            data=random.randbytes(data_size)
+        )
+
+    # Reset sequence (active-low reset)
+    await drive_reset(reset=dut.nreset, time_ns=10)
+
+    # Start clock
+    Clock(dut.clk, 1, unit="ns").start()
+
+    await ClockCycles(dut.clk, 10)
+
+    ########################################################
+    # Send UMI transaction on umi[1] interface
+    ########################################################
+    umi_1_trans: SumiTransaction = rand_transaction()
+    umi_drivers[1].append(umi_1_trans)
+    await RisingEdge(dut.umi_out_valid)
+
+    ########################################################
+    # Check that transaction propagated to output
+    ########################################################
+    await ClockCycles(dut.clk, 1)
+    assert dut.umi_out_data.value.to_bytes(byteorder="little") == umi_1_trans.data
+
+    ########################################################
+    # Send a transaction on umi[0] interface before
+    # accepting the transaction on umi[1]
+    ########################################################
+    umi_0_trans: SumiTransaction = copy.deepcopy(umi_1_trans)
+    umi_0_trans.data = bytes(b ^ 0xff for b in umi_0_trans.data)
+    umi_drivers[0].append(umi_0_trans)
+    await ClockCycles(dut.clk, 1)
+
+    ########################################################
+    # Verify that umi[1] transaction is still waiting to
+    # be accepted on the output
+    ########################################################
+    assert dut.umi_out_data.value.to_bytes(byteorder="little") == umi_1_trans.data, \
+        "ERROR: UMI out data changed when no transaction occurred."
+
+    ########################################################
+    # Accept umi[1] transaction
+    ########################################################
+    dut.umi_out_ready.value = 1
+    await ClockCycles(dut.clk, 1)
+    dut.umi_out_ready.value = 0
+    await ClockCycles(dut.clk, 1)
+
+    ########################################################
+    # Verify that umi[0] transaction is now present
+    ########################################################
+    assert dut.umi_out_data.value.to_bytes(byteorder="little") == umi_0_trans.data
+
+    ########################################################
+    # Accept umi[0] transaction
+    ########################################################
+    dut.umi_out_ready.value = 1
+    await ClockCycles(dut.clk, 1)
+    dut.umi_out_ready.value = 0
+    await ClockCycles(dut.clk, 10)
+
+
 class TbDesign(Design):
 
     def __init__(self):
@@ -133,13 +237,13 @@ class TbDesign(Design):
 
         self.set_name("tb_umi_mux")
 
-        self.set_dataroot("tb_umi_mux", __file__)
+        self.set_dataroot("local", __file__)
 
-        with self.active_dataroot("tb_umi_mux"):
+        with self.active_dataroot("local"):
             with self.active_fileset("testbench.cocotb"):
                 self.set_topmodule("tb_umi_mux")
                 self.add_file("tb_umi_mux.v")
-                self.add_file(Path(__file__).name, filetype="python")
+                self.add_file("test_umi_mux.py", filetype="python")
                 self.add_depfileset(Mux(), "rtl")
 
 

--- a/umi/sumi/umi_mux/rtl/umi_mux.v
+++ b/umi/sumi/umi_mux/rtl/umi_mux.v
@@ -47,6 +47,14 @@ module umi_mux
     );
 
    wire [N-1:0]    grants;
+   wire [N-1:0]    sel_oh;
+
+   wire umi_out_fire;
+   wire stall;
+   wire stalled;
+
+   reg [N-1:0]     stalled_input;
+
 
    //##############################
    // Valid Arbiter
@@ -62,14 +70,32 @@ module umi_mux
                 .mask     (arbmask[N-1:0]),
                 .requests (umi_in_valid[N-1:0]));
 
-   assign umi_out_valid = |grants[N-1:0];
+   assign umi_out_valid = |sel_oh[N-1:0];
+
+   //#######################################################
+   // When umi_out stalls capture and hold grants state
+   //#######################################################
+
+   assign umi_out_fire = umi_out_valid & umi_out_ready;
+   assign stall = umi_out_valid & ~umi_out_ready;
+   assign stalled = stalled_input[N-1:0] != {N{1'b0}};
+
+   always @(posedge clk or negedge nreset)
+      if (~nreset)
+         stalled_input[N-1:0] <= {N{1'b0}};
+      else if (umi_out_fire)
+         stalled_input[N-1:0] <= {N{1'b0}};
+      else if (~stalled & stall)
+         stalled_input[N-1:0] <= grants[N-1:0];
+
+   assign sel_oh[N-1:0] = stalled ? stalled_input[N-1:0] : grants[N-1:0];
 
    //##############################
    // Ready
    //##############################
 
    // Allow umi_out_ready to propagate to the umi port currently granted access
-   assign umi_in_ready[N-1:0] = grants[N-1:0] & {N{umi_out_ready}};
+   assign umi_in_ready[N-1:0] = sel_oh[N-1:0] & {N{umi_out_ready}};
 
    //##############################
    // Output Mux
@@ -81,7 +107,7 @@ module umi_mux
    la_data_vmux(// Outputs
                 .out (umi_out_data[DW-1:0]),
                 // Inputs
-                .sel (grants[N-1:0]),
+                .sel (sel_oh[N-1:0]),
                 .in  (umi_in_data[N*DW-1:0]));
 
    // srcaddr
@@ -90,7 +116,7 @@ module umi_mux
    la_src_vmux(// Outputs
                .out (umi_out_srcaddr[AW-1:0]),
                // Inputs
-               .sel (grants[N-1:0]),
+               .sel (sel_oh[N-1:0]),
                .in  (umi_in_srcaddr[N*AW-1:0]));
 
    // dstaddr
@@ -99,7 +125,7 @@ module umi_mux
    la_dst_vmux(// Outputs
                .out (umi_out_dstaddr[AW-1:0]),
                // Inputs
-               .sel (grants[N-1:0]),
+               .sel (sel_oh[N-1:0]),
                .in  (umi_in_dstaddr[N*AW-1:0]));
 
    // command
@@ -108,7 +134,7 @@ module umi_mux
    la_cmd_vmux(// Outputs
                .out (umi_out_cmd[CW-1:0]),
                // Inputs
-               .sel (grants[N-1:0]),
+               .sel (sel_oh[N-1:0]),
                .in  (umi_in_cmd[N*CW-1:0]));
 
 endmodule


### PR DESCRIPTION
Makes UMI mux compliant with umi spec handshake rule 3:

```While VALID is asserted, the packet fields (CMD, DSTADDR, SRCADDR, DATA) must remain stable until the transaction completes.```