### PR TITLE
Follow-on to #298

### DIFF
--- a/tests/sumi/test_checker_testbench.py
+++ b/tests/sumi/test_checker_testbench.py
@@ -11,18 +11,18 @@ header says so:
 
   * the handshake testbench ends in $finish on both passes, so its
     inject pass exits zero even though the checker fired;
-  * the command and transaction testbenches end in $fatal whenever their
-    own expectation disagrees with the checker, so a MISSED detection
-    also exits nonzero.
+  * the command, transaction and frame testbenches end in $fatal
+    whenever their own expectation disagrees with the checker, so a
+    MISSED detection also exits nonzero.
 
 The text is what separates the outcomes. A clean pass must print
 "TB PASS" and no checker error at all; an inject pass must print the
 expected checker error and no "TB FAIL".
 
-Icarus is the simulator here because all three testbenches run correctly
+Icarus is the simulator here because all four testbenches run correctly
 under it. Verilator defers $finish to the end of the time step, so the
-statements guarding the command and transaction verdicts still execute
-after the clean pass has asked to stop.
+statements guarding those verdicts still execute after the clean pass
+has asked to stop.
 """
 import shutil
 import subprocess
@@ -43,12 +43,13 @@ pytestmark = [
 
 # checker name, the message tag it prints on any violation, the specific
 # error the inject pass must produce, and whether that pass ends in
-# $fatal. Only the command and transaction testbenches have a verdict of
-# their own to disagree with, so only they exit nonzero.
+# $fatal. The handshake testbench has no verdict of its own to disagree
+# with, so it is the only one whose inject pass exits zero.
 CASES = [
     ("handshake", "UMI-HS", "UMI-HS RULE3", False),
     ("cmd", "UMI-CMD", "UMI-CMD CMD-1", True),
     ("txn", "UMI-TXN", "UMI-TXN da_cont", True),
+    ("frame", "UMI-FRAME", "UMI-FRAME size", True),
 ]
 
 

--- a/tests/sumi/test_checker_testbench.py
+++ b/tests/sumi/test_checker_testbench.py
@@ -1,7 +1,10 @@
 """Simulation self-tests for the umi_checker protocol checkers.
 
 umi/sumi/umi_checker/testbench/ ships one self-checking testbench per
-checker. Each is run twice: a clean pass over legal traffic, and a
+checker, alongside the worked bind example that tests/sumi/
+test_checker_bind.py drives. This runner covers the four testbenches,
+not the bind example. Each is run twice: a clean pass over legal
+traffic, and a
 "+inject" pass carrying exactly one planted protocol violation that the
 checker must report. This runner drives both passes with Icarus Verilog
 and checks the printed output.

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -45,8 +45,8 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
-                      Fifo, Isolate, Monitor, Mux, Mux2, Pack, Pipeline,
-                      Stream, Unpack)
+                      Fifo, Isolate, Memif, Monitor, Mux, Mux2, Pack,
+                      Pipeline, Stream, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -123,6 +123,7 @@ FAMILIES = {
                         timeout=900),
     "fv_umi_stream": dict(deps=lambda: [Stream(), Checker()], depth=14,
                           timeout=900),
+    "fv_umi_memif": dict(deps=lambda: [Memif()], depth=6, timeout=900),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -329,6 +330,10 @@ GREEN = [
     Proof("crossbar:prove", "fv_umi_crossbar", "prove"),
     Proof("crossbar:cover", "fv_umi_crossbar", "cover"),
 
+    # ---- fv_umi_memif -------------------------------------------------
+    Proof("memif:prove", "fv_umi_memif", "prove"),
+    Proof("memif:cover", "fv_umi_memif", "cover"),
+
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
     # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
@@ -481,6 +486,18 @@ FAULTS = [
           defines=("FV_FAULT_USI_HOLD",), expect="a_usi_out_hold"),
     Proof("stream:fault_usi_stable", "fv_umi_stream", "bmc",
           defines=("FV_FAULT_USI_STABLE",), expect="a_usi_out_stable"),
+
+    # ---- fv_umi_memif -------------------------------------------------
+    # each fault is confined to one ATYPE so it can convict only its
+    # own law
+    Proof("memif:fault_add", "fv_umi_memif", "bmc",
+          defines=("FV_FAULT_ADD",), expect="a_alu_add"),
+    Proof("memif:fault_smax", "fv_umi_memif", "bmc",
+          defines=("FV_FAULT_SMAX",), expect="a_alu_smax"),
+    Proof("memif:fault_swap", "fv_umi_memif", "bmc",
+          defines=("FV_FAULT_SWAP",), expect="a_alu_swap"),
+    Proof("memif:fault_default", "fv_umi_memif", "bmc",
+          defines=("FV_FAULT_DEFAULT",), expect="a_alu_default"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -45,7 +45,8 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
-                      Isolate, Monitor, Mux, Mux2, Pack, Pipeline, Unpack)
+                      Fifo, Isolate, Monitor, Mux, Mux2, Pack, Pipeline,
+                      Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -118,6 +119,8 @@ FAMILIES = {
     "fv_umi_decode": dict(deps=lambda: [Decode()], depth=4, timeout=300),
     "fv_umi_isolate": dict(deps=lambda: [Isolate()], depth=4, timeout=300),
     "fv_umi_monitor": dict(deps=lambda: [Monitor()], depth=12, timeout=300),
+    "fv_umi_fifo": dict(deps=lambda: [Fifo(), Checker()], depth=16,
+                        timeout=900),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -238,6 +241,24 @@ GREEN = [
     # ---- fv_umi_monitor -----------------------------------------------
     Proof("monitor:prove", "fv_umi_monitor", "prove"),
     Proof("monitor:cover", "fv_umi_monitor", "cover"),
+
+    # ---- fv_umi_fifo --------------------------------------------------
+    # bounded, not prove: the pointers reach la_drsync registers no port
+    # shows, so induction starts from states no trace reaches. See the
+    # note in fv_umi_fifo.sv
+    Proof("fifo:bmc", "fv_umi_fifo", "bmc"),
+    Proof("fifo:bmc_bypass", "fv_umi_fifo", "bmc", params=(("BYPASS", "1"),)),
+    Proof("fifo:cover", "fv_umi_fifo", "cover"),
+    Proof("fifo:identity", "fv_umi_fifo", "bmc", defines=("FV_IDENTITY",),
+          params=(("DEPTH", "2"),)),
+    Proof("fifo:identity_bypass", "fv_umi_fifo", "bmc",
+          defines=("FV_IDENTITY",), params=(("BYPASS", "1"),)),
+    Proof("fifo:identity_cover", "fv_umi_fifo", "cover",
+          defines=("FV_IDENTITY",), params=(("DEPTH", "2"),)),
+    # the bypass arm states the same three laws over different logic, so
+    # it needs its own witnesses
+    Proof("fifo:identity_cover_bypass", "fv_umi_fifo", "cover",
+          defines=("FV_IDENTITY",), params=(("BYPASS", "1"),)),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:prove", "fv_umi_demux", "prove"),
@@ -400,6 +421,18 @@ FAULTS = [
     # ---- fv_umi_monitor -----------------------------------------------
     Proof("monitor:fault_or", "fv_umi_monitor", "bmc",
           defines=("FV_FAULT_OR",), expect="a_mon_beat"),
+
+    # ---- fv_umi_fifo --------------------------------------------------
+    Proof("fifo:fault_valid", "fv_umi_fifo", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
+    Proof("fifo:fault_data", "fv_umi_fifo", "bmc",
+          defines=("FV_FAULT_DATA",), expect="RULE3_data_stable"),
+    Proof("fifo:fault_swap", "fv_umi_fifo", "bmc",
+          defines=("FV_IDENTITY", "FV_FAULT_SWAP"), params=(("DEPTH", "2"),),
+          expect="a_fifo_beat"),
+    Proof("fifo:fault_ghost", "fv_umi_fifo", "bmc",
+          defines=("FV_IDENTITY", "FV_FAULT_GHOST"), params=(("DEPTH", "2"),),
+          expect="a_fifo_no_underflow"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Demux, Mux, Mux2,
-                      Pack, Unpack)
+                      Pack, Pipeline, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -113,6 +113,8 @@ FAMILIES = {
     "fv_umi_mux": dict(deps=lambda: [Mux(), Checker()], depth=12, timeout=300),
     "fv_umi_mux2": dict(deps=lambda: [Mux2(), Checker()], depth=12, timeout=300),
     "fv_umi_crossbar": dict(deps=lambda: [Crossbar(), Checker()], depth=12, timeout=300),
+    "fv_umi_pipeline": dict(deps=lambda: [Pipeline(), Checker()], depth=12,
+                            timeout=300),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -198,6 +200,21 @@ GREEN = [
     Proof("buffer:identity_cover_bypass", "fv_umi_buffer", "cover",
           defines=("FV_IDENTITY",),
           params=(("MODE", "0"), ("AW", "16"), ("DW", "32"))),
+
+    # ---- fv_umi_pipeline ----------------------------------------------
+    Proof("pipeline:prove", "fv_umi_pipeline", "prove"),
+    Proof("pipeline:cover", "fv_umi_pipeline", "cover"),
+    # identity rides its own rows: the accounting law reads the same
+    # obs_valid the handshake faults corrupt and would convict a cycle
+    # ahead of the rule those rows are aimed at
+    Proof("pipeline:identity", "fv_umi_pipeline", "prove",
+          defines=("FV_IDENTITY",)),
+    Proof("pipeline:identity_cover", "fv_umi_pipeline", "cover",
+          defines=("FV_IDENTITY",)),
+    # as buffer:prove_mask_off -- a free output channel with the mask
+    # cleared reports nothing; the fault_mask_* rows enable one bit each
+    Proof("pipeline:prove_mask_off", "fv_umi_pipeline", "prove",
+          defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "0"),)),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:prove", "fv_umi_demux", "prove"),
@@ -320,6 +337,26 @@ FAULTS = [
     Proof("buffer:fault_mask_reset", "fv_umi_buffer", "bmc",
           defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "32"),),
           expect="RESET_valid_low"),
+
+    # ---- fv_umi_pipeline ----------------------------------------------
+    Proof("pipeline:fault_valid", "fv_umi_pipeline", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
+    Proof("pipeline:fault_data", "fv_umi_pipeline", "bmc",
+          defines=("FV_FAULT_DATA",), expect="RULE3_data_stable"),
+    # the two addresses exchanged: every handshake rule still holds, so
+    # only the identity law can see it
+    Proof("pipeline:fault_swap", "fv_umi_pipeline", "bmc",
+          defines=("FV_IDENTITY", "FV_FAULT_SWAP"), expect="a_pipe_beat"),
+    # a beat the stage never accepted: the accounting law catches it
+    Proof("pipeline:fault_ghost", "fv_umi_pipeline", "bmc",
+          defines=("FV_IDENTITY", "FV_FAULT_GHOST"),
+          expect="a_pipe_occupancy"),
+    Proof("pipeline:fault_mask_r2", "fv_umi_pipeline", "bmc",
+          defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "1"),),
+          expect="RULE2_valid_hold"),
+    Proof("pipeline:fault_mask_r3data", "fv_umi_pipeline", "bmc",
+          defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "16"),),
+          expect="RULE3_data_stable"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -45,8 +45,8 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
-                      Endpoint, Fifo, Isolate, Memif, Monitor, Mux, Mux2,
-                      Pack, Pipeline, RAM, Regif, Stream, Unpack)
+                      Endpoint, Fifo, FifoFlex, Isolate, Memif, Monitor, Mux,
+                      Mux2, Pack, Pipeline, RAM, Regif, Stream, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -130,6 +130,8 @@ FAMILIES = {
                             timeout=900),
     "fv_umi_ram": dict(deps=lambda: [RAM(), Checker()], depth=10,
                        timeout=1800),
+    "fv_umi_fifoflex": dict(deps=lambda: [FifoFlex(), Checker()], depth=12,
+                            timeout=1800),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -376,6 +378,21 @@ GREEN = [
     Proof("ram:hazard", "fv_umi_ram", "cover",
           defines=("FV_RAM_NOCHK", "FV_RAM_ANYID")),
 
+    # ---- fv_umi_fifoflex ----------------------------------------------
+    # bounded: a conservation law over running counters is not
+    # inductive, and the exact in-flight figure lives in latch_bytes,
+    # which is not a port. See the harness header.
+    Proof("fifoflex:bmc", "fv_umi_fifoflex", "bmc", params=(("SPLIT", "0"),)),
+    # the merge arm is a separate circuit and keeps the law with the
+    # splitter enabled
+    Proof("fifoflex:bmc_merge", "fv_umi_fifoflex", "bmc",
+          params=(("IDW", "64"), ("ODW", "128"))),
+    Proof("fifoflex:cover", "fv_umi_fifoflex", "cover"),
+    # alignment withdrawn: the split arm's length arithmetic underflows
+    # on an unaligned address, which is behaviour of the shipped block
+    Proof("fifoflex:hazard", "fv_umi_fifoflex", "cover",
+          defines=("FV_FLEX_NOALIGN",), params=(("IDW", "128"), ("ODW", "64"))),
+
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
     # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
@@ -580,6 +597,16 @@ FAULTS = [
     # standing unaccepted. Pinned so the finding cannot regress
     Proof("ram:fault_stable", "fv_umi_ram", "bmc",
           expect="RULE3_dstaddr_stable"),
+
+    # ---- fv_umi_fifoflex ----------------------------------------------
+    Proof("fifoflex:fault_valid", "fv_umi_fifoflex", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
+    Proof("fifoflex:fault_invent", "fv_umi_fifoflex", "bmc",
+          defines=("FV_FAULT_INVENT",), expect="a_flex_conserve"),
+    # nothing injected: with SPLIT=1 the block delivers bytes it was
+    # never given. umi_memagent instantiates it exactly this way
+    Proof("fifoflex:fault_split", "fv_umi_fifoflex", "bmc",
+          params=(("SPLIT", "1"),), expect="a_flex_conserve"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -140,6 +140,7 @@ FAMILIES = {
                             timeout=1800),
     "fv_umi_switch": dict(deps=lambda: [Switch(), Checker()], depth=12,
                           timeout=1800),
+    "fv_umi_frame": dict(deps=lambda: [Checker()], depth=10, timeout=900),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -317,6 +318,19 @@ GREEN = [
     Proof("cmd:cover_invalid", "fv_umi_cmd", "cover",
           params=(("ALLOW_INVALID", "1"),)),
     Proof("cmd:prove_mask_off", "fv_umi_cmd", "prove", params=(("RULE_EN", "0"),)),
+
+    # ---- fv_umi_frame -------------------------------------------------
+    # the request-side half umi_txn_checker's header records as missing.
+    # Checker against checker, so induction closes on the shadow state
+    # bounded: FRAME_msgbytes accumulates over a message, and a free
+    # accumulator in the step case can start above the ceiling, so the
+    # rule does not close by induction. The other five are cycle-local
+    Proof("frame:bmc", "fv_umi_frame", "bmc"),
+    Proof("frame:cover", "fv_umi_frame", "cover"),
+    # as buffer:prove_mask_off -- a free observed channel with the mask
+    # cleared reports nothing; fault_mask_da enables one bit
+    Proof("frame:bmc_mask_off", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "0"),)),
 
     # ---- fv_umi_txn ---------------------------------------------------
     Proof("txn:prove", "fv_umi_txn", "prove"),
@@ -691,6 +705,28 @@ FAULTS = [
           expect="CMD6_sa_reserved"),
     Proof("cmd:fault_invalid", "fv_umi_cmd", "bmc", defines=("FV_FAULT_INVALID",),
           expect="CMD1_opcode_legal"),
+
+    # ---- fv_umi_frame -------------------------------------------------
+    # one row per rule, each bending exactly that rule on the observed
+    # channel while the driving channel stays legal
+    Proof("frame:fault_size", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_SIZE",), expect="FRAME_size_stable"),
+    Proof("frame:fault_opcode", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_OPCODE",), expect="FRAME_opcode_stable"),
+    Proof("frame:fault_fields", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_FIELDS",), expect="FRAME_fields_stable"),
+    Proof("frame:fault_da", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_DA",), expect="FRAME_da_cont"),
+    Proof("frame:fault_sa", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_SA",), expect="FRAME_sa_cont"),
+    # a message that never closes runs past the ceiling; lowered so the
+    # boundary is reachable inside the bounded depth
+    Proof("frame:fault_bytes", "fv_umi_frame", "bmc", depth=14,
+          defines=("FV_FAULT_BYTES",), expect="FRAME_msgbytes"),
+    # the mask is falsifiable: only bit 3 enabled, so FRAME_da_cont alone
+    Proof("frame:fault_mask_da", "fv_umi_frame", "bmc",
+          defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "8"),),
+          expect="FRAME_da_cont"),
 
     # ---- fv_umi_txn ---------------------------------------------------
     Proof("txn:fault_wrongda", "fv_umi_txn", "bmc", defines=("FV_FAULT_WRONGDA",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -429,33 +429,81 @@ GREEN = [
 
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
-    # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
-    # than README 4.1 permits, which is fine for a routing law but is
-    # not a configuration any UMI device ships. These rows re-answer the
-    # same questions at widths the specification allows and at the width
-    # nine blocks in this repo actually default to, so a truncation that
-    # only appears in a wide counter cannot hide behind a narrow proof.
+    # four of them (demux, mux, mux2, crossbar) run AW=16/DW=32 --
+    # narrower than README 4.1 permits, which is fine for a routing law
+    # but is not a configuration any UMI device ships. These rows
+    # re-answer the same questions at widths the specification allows
+    # and at the width nine blocks in this repo actually default to, so
+    # a truncation that only appears in a wide counter cannot hide
+    # behind a narrow proof.
+    #
+    # Every proof here is paired with a cover row at the SAME face. A
+    # proof at a new width can pass for the wrong reason: if widening
+    # made some assumption unsatisfiable, every assertion under it holds
+    # vacuously and the row goes green while checking nothing. The
+    # paired cover is what rules that out -- it must still reach every
+    # witness, and the counts are in the folder README.
     Proof("buffer:prove_dw256", "fv_umi_buffer", "prove",
+          params=(("DW", "256"),)),
+    Proof("buffer:cover_dw256", "fv_umi_buffer", "cover",
           params=(("DW", "256"),)),
     Proof("buffer:prove_aw32", "fv_umi_buffer", "prove",
           params=(("AW", "32"),)),
+    Proof("buffer:cover_aw32", "fv_umi_buffer", "cover",
+          params=(("AW", "32"),)),
     Proof("demux:prove_legal", "fv_umi_demux", "prove",
+          params=(("AW", "64"), ("DW", "64"))),
+    Proof("demux:cover_legal", "fv_umi_demux", "cover",
           params=(("AW", "64"), ("DW", "64"))),
     Proof("mux2:prove_legal", "fv_umi_mux2", "prove",
           params=(("AW", "64"), ("DW", "64"))),
     Proof("crossbar:prove_legal", "fv_umi_crossbar", "prove",
           params=(("AW", "64"), ("DW", "64"))),
+    # umi_mux runs the same narrow face as its three neighbours above
+    # and was left out of the first widening. It answers bmc, not
+    # prove, for the reason its harness header gives.
+    Proof("mux:bmc_legal", "fv_umi_mux", "bmc",
+          params=(("AW", "64"), ("DW", "64"))),
+    Proof("mux:cover_legal", "fv_umi_mux", "cover",
+          params=(("AW", "64"), ("DW", "64"))),
     Proof("pipeline:prove_dw256", "fv_umi_pipeline", "prove",
+          params=(("DW", "256"),)),
+    Proof("pipeline:cover_dw256", "fv_umi_pipeline", "cover",
+          params=(("DW", "256"),)),
+    # AW=32 is the other address width README 4.1 permits, and the one
+    # nothing was elaborated at until the buffer rows above
+    Proof("mux2:prove_aw32", "fv_umi_mux2", "prove",
+          params=(("AW", "32"), ("DW", "64"))),
+    Proof("mux2:cover_aw32", "fv_umi_mux2", "cover",
+          params=(("AW", "32"), ("DW", "64"))),
+    Proof("crossbar:prove_aw32", "fv_umi_crossbar", "prove",
+          params=(("AW", "32"), ("DW", "64"))),
+    Proof("crossbar:cover_aw32", "fv_umi_crossbar", "cover",
+          params=(("AW", "32"), ("DW", "64"))),
+    Proof("pipeline:prove_aw32", "fv_umi_pipeline", "prove",
+          params=(("AW", "32"),)),
+    Proof("pipeline:cover_aw32", "fv_umi_pipeline", "cover",
+          params=(("AW", "32"),)),
+    Proof("isolate:prove_dw256", "fv_umi_isolate", "prove",
+          params=(("DW", "256"),)),
+    Proof("isolate:cover_dw256", "fv_umi_isolate", "cover",
+          params=(("DW", "256"),)),
+    Proof("isolate:prove_aw32", "fv_umi_isolate", "prove",
+          params=(("AW", "32"),)),
+    Proof("isolate:cover_aw32", "fv_umi_isolate", "cover",
+          params=(("AW", "32"),)),
+    Proof("regif:prove_dw256", "fv_umi_regif", "prove",
+          params=(("DW", "256"),)),
+    Proof("regif:cover_dw256", "fv_umi_regif", "cover",
+          params=(("DW", "256"),)),
+    Proof("monitor:prove_dw256", "fv_umi_monitor", "prove",
+          params=(("DW", "256"),)),
+    Proof("monitor:cover_dw256", "fv_umi_monitor", "cover",
           params=(("DW", "256"),)),
     # the repo's own RAM testbench instantiates the arbiter at N=5; the
     # proofs above stop at 4, and the thermometer is N-asymmetric
     Proof("arbiter:prove_n5", "fv_umi_arbiter", "prove",
           params=(("N", "5"),)),
-    # a widened face could pass vacuously if it made some assumption
-    # unsatisfiable, so one cover row rides the matrix: the environment
-    # must still reach every witness at the legal width
-    Proof("demux:cover_legal", "fv_umi_demux", "cover",
-          params=(("AW", "64"), ("DW", "64"))),
 ]
 
 FAULTS = [

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -48,6 +48,12 @@ from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
                       Endpoint, Fifo, FifoFlex, Isolate, Memif, Monitor, Mux,
                       Mux2, Pack, Pipeline, RAM, Regif, Stream, Unpack)
 
+# umi_switch is deliberately not re-exported from umi.sumi -- see
+# "Disabling umi_switch in api for safety reasons". Reaching past the
+# package API keeps that decision intact while still letting the block
+# be judged; fv_umi_switch.sv states what the disabled path does.
+from umi.sumi.umi_switch.umi_switch import Switch
+
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
 SUMI_INCLUDE = REPO / "umi" / "sumi" / "include"
@@ -132,6 +138,8 @@ FAMILIES = {
                        timeout=1800),
     "fv_umi_fifoflex": dict(deps=lambda: [FifoFlex(), Checker()], depth=12,
                             timeout=1800),
+    "fv_umi_switch": dict(deps=lambda: [Switch(), Checker()], depth=12,
+                          timeout=1800),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -393,6 +401,18 @@ GREEN = [
     Proof("fifoflex:hazard", "fv_umi_fifoflex", "cover",
           defines=("FV_FLEX_NOALIGN",), params=(("IDW", "128"), ("ODW", "64"))),
 
+    # ---- fv_umi_switch ------------------------------------------------
+    # bounded: the arbiter thermometer and the mux's captured
+    # stalled_input are not observable from these ports, the same fence
+    # fv_umi_mux documents
+    Proof("switch:bmc", "fv_umi_switch", "bmc"),
+    # M=2 turns the ready merge on: every output's per-input ready is
+    # ANDed together, so acceptance depends on the stalled-grant history
+    # of outputs an input is not even asking for. See the harness header
+    Proof("switch:bmc_m2", "fv_umi_switch", "bmc", params=(("M", "2"),)),
+    Proof("switch:cover_m2", "fv_umi_switch", "cover", params=(("M", "2"),)),
+    Proof("switch:cover", "fv_umi_switch", "cover"),
+
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
     # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
@@ -607,6 +627,10 @@ FAULTS = [
     # never given. umi_memagent instantiates it exactly this way
     Proof("fifoflex:fault_split", "fv_umi_fifoflex", "bmc",
           params=(("SPLIT", "1"),), expect="a_flex_conserve"),
+
+    # ---- fv_umi_switch ------------------------------------------------
+    Proof("switch:fault_valid", "fv_umi_switch", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -44,8 +44,8 @@ try:
 except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
-from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Demux, Mux, Mux2,
-                      Pack, Pipeline, Unpack)
+from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux, Mux,
+                      Mux2, Pack, Pipeline, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -115,6 +115,7 @@ FAMILIES = {
     "fv_umi_crossbar": dict(deps=lambda: [Crossbar(), Checker()], depth=12, timeout=300),
     "fv_umi_pipeline": dict(deps=lambda: [Pipeline(), Checker()], depth=12,
                             timeout=300),
+    "fv_umi_decode": dict(deps=lambda: [Decode()], depth=4, timeout=300),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -215,6 +216,14 @@ GREEN = [
     # cleared reports nothing; the fault_mask_* rows enable one bit each
     Proof("pipeline:prove_mask_off", "fv_umi_pipeline", "prove",
           defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "0"),)),
+
+    # ---- fv_umi_decode ------------------------------------------------
+    Proof("decode:prove", "fv_umi_decode", "prove"),
+    Proof("decode:cover", "fv_umi_decode", "cover"),
+    # the legal-opcode assumption withdrawn: the structural laws still
+    # hold and the covers pin what the four-bit compares admit
+    Proof("decode:hazard", "fv_umi_decode", "cover",
+          defines=("FV_DEC_ANYOPCODE",)),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:prove", "fv_umi_demux", "prove"),
@@ -357,6 +366,16 @@ FAULTS = [
     Proof("pipeline:fault_mask_r3data", "fv_umi_pipeline", "bmc",
           defines=("FV_FAULT_FREEOUT",), params=(("RULE_EN", "16"),),
           expect="RULE3_data_stable"),
+
+    # ---- fv_umi_decode ------------------------------------------------
+    Proof("decode:fault_read", "fv_umi_decode", "bmc",
+          defines=("FV_FAULT_READ",), expect="DEC_read"),
+    Proof("decode:fault_onehot", "fv_umi_decode", "bmc",
+          defines=("FV_FAULT_ONEHOT",), expect="DEC_class_onehot0"),
+    Proof("decode:fault_req", "fv_umi_decode", "bmc",
+          defines=("FV_FAULT_REQ",), expect="DEC_req_implies"),
+    Proof("decode:fault_atomic", "fv_umi_decode", "bmc",
+          defines=("FV_FAULT_ATOMIC",), expect="DEC_atomic_onehot0"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -502,7 +502,13 @@ GREEN = [
           params=(("DW", "256"),)),
     # the repo's own RAM testbench instantiates the arbiter at N=5; the
     # proofs above stop at 4, and the thermometer is N-asymmetric
+    Proof("mux2:cover_legal", "fv_umi_mux2", "cover",
+          params=(("AW", "64"), ("DW", "64"))),
+    Proof("crossbar:cover_legal", "fv_umi_crossbar", "cover",
+          params=(("AW", "64"), ("DW", "64"))),
     Proof("arbiter:prove_n5", "fv_umi_arbiter", "prove",
+          params=(("N", "5"),)),
+    Proof("arbiter:cover_n5", "fv_umi_arbiter", "cover",
           params=(("N", "5"),)),
 ]
 

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
                       Fifo, Isolate, Monitor, Mux, Mux2, Pack, Pipeline,
-                      Unpack)
+                      Stream, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -121,6 +121,8 @@ FAMILIES = {
     "fv_umi_monitor": dict(deps=lambda: [Monitor()], depth=12, timeout=300),
     "fv_umi_fifo": dict(deps=lambda: [Fifo(), Checker()], depth=16,
                         timeout=900),
+    "fv_umi_stream": dict(deps=lambda: [Stream(), Checker()], depth=14,
+                          timeout=900),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -259,6 +261,12 @@ GREEN = [
     # it needs its own witnesses
     Proof("fifo:identity_cover_bypass", "fv_umi_fifo", "cover",
           defines=("FV_IDENTITY",), params=(("BYPASS", "1"),)),
+
+    # ---- fv_umi_stream ------------------------------------------------
+    # bounded for the reason fv_umi_fifo gives: the FIFO pointers cross
+    # synchroniser registers no port shows
+    Proof("stream:bmc", "fv_umi_stream", "bmc"),
+    Proof("stream:cover", "fv_umi_stream", "cover"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:prove", "fv_umi_demux", "prove"),
@@ -433,6 +441,16 @@ FAULTS = [
     Proof("fifo:fault_ghost", "fv_umi_fifo", "bmc",
           defines=("FV_IDENTITY", "FV_FAULT_GHOST"), params=(("DEPTH", "2"),),
           expect="a_fifo_no_underflow"),
+
+    # ---- fv_umi_stream ------------------------------------------------
+    Proof("stream:fault_valid", "fv_umi_stream", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
+    Proof("stream:fault_data", "fv_umi_stream", "bmc",
+          defines=("FV_FAULT_DATA",), expect="RULE3_data_stable"),
+    Proof("stream:fault_usi_hold", "fv_umi_stream", "bmc",
+          defines=("FV_FAULT_USI_HOLD",), expect="a_usi_out_hold"),
+    Proof("stream:fault_usi_stable", "fv_umi_stream", "bmc",
+          defines=("FV_FAULT_USI_STABLE",), expect="a_usi_out_stable"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
                       Fifo, Isolate, Memif, Monitor, Mux, Mux2, Pack,
-                      Pipeline, Stream, Unpack)
+                      Pipeline, Regif, Stream, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -124,6 +124,8 @@ FAMILIES = {
     "fv_umi_stream": dict(deps=lambda: [Stream(), Checker()], depth=14,
                           timeout=900),
     "fv_umi_memif": dict(deps=lambda: [Memif()], depth=6, timeout=900),
+    "fv_umi_regif": dict(deps=lambda: [Regif(), Checker()], depth=12,
+                         timeout=900),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -334,6 +336,16 @@ GREEN = [
     Proof("memif:prove", "fv_umi_memif", "prove"),
     Proof("memif:cover", "fv_umi_memif", "cover"),
 
+    # ---- fv_umi_regif -------------------------------------------------
+    Proof("regif:prove", "fv_umi_regif", "prove"),
+    Proof("regif:cover", "fv_umi_regif", "cover"),
+    # SAFE=1 breaks the resp_ready to req_ready path on purpose, so a
+    # second request can land while the first answer still stands. The
+    # response checker is lifted and the overwrite is witnessed
+    Proof("regif:hazard", "fv_umi_regif", "cover",
+          defines=("FV_REGIF_NOCHK", "FV_REGIF_HAZARD"),
+          params=(("SAFE", "1"),)),
+
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
     # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
@@ -498,6 +510,22 @@ FAULTS = [
           defines=("FV_FAULT_SWAP",), expect="a_alu_swap"),
     Proof("memif:fault_default", "fv_umi_memif", "bmc",
           defines=("FV_FAULT_DEFAULT",), expect="a_alu_default"),
+
+    # ---- fv_umi_regif -------------------------------------------------
+    Proof("regif:fault_valid", "fv_umi_regif", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
+    # the xor swaps the two response opcodes, so either half of the
+    # kind law can catch it; the solver reaches the write side first
+    Proof("regif:fault_kind", "fv_umi_regif", "bmc",
+          defines=("FV_FAULT_KIND",), expect="a_regif_kind_wr"),
+    Proof("regif:fault_posted", "fv_umi_regif", "bmc",
+          defines=("FV_FAULT_POSTED",), expect="a_regif_no_invent"),
+    # nothing injected: SAFE=1 is the shipped default, and it breaks the
+    # accounting law on its own. Pinned so the finding cannot regress
+    # into silence
+    Proof("regif:fault_safe", "fv_umi_regif", "bmc",
+          defines=("FV_REGIF_NOCHK",), params=(("SAFE", "1"),),
+          expect="a_regif_outstanding"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -45,8 +45,8 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
-                      Fifo, Isolate, Memif, Monitor, Mux, Mux2, Pack,
-                      Pipeline, Regif, Stream, Unpack)
+                      Endpoint, Fifo, Isolate, Memif, Monitor, Mux, Mux2,
+                      Pack, Pipeline, Regif, Stream, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -126,6 +126,8 @@ FAMILIES = {
     "fv_umi_memif": dict(deps=lambda: [Memif()], depth=6, timeout=900),
     "fv_umi_regif": dict(deps=lambda: [Regif(), Checker()], depth=12,
                          timeout=900),
+    "fv_umi_endpoint": dict(deps=lambda: [Endpoint(), Checker()], depth=12,
+                            timeout=900),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -346,6 +348,15 @@ GREEN = [
           defines=("FV_REGIF_NOCHK", "FV_REGIF_HAZARD"),
           params=(("SAFE", "1"),)),
 
+    # ---- fv_umi_endpoint ----------------------------------------------
+    Proof("endpoint:prove", "fv_umi_endpoint", "prove"),
+    # bounded, not prove: REG=1 holds a second answer in a pipeline
+    # stage no port shows, so the exact count is not expressible and a
+    # bare bound on wrapping counters does not close by induction
+    Proof("endpoint:bmc_reg", "fv_umi_endpoint", "bmc",
+          params=(("REG", "1"),)),
+    Proof("endpoint:cover", "fv_umi_endpoint", "cover"),
+
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
     # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
@@ -526,6 +537,21 @@ FAULTS = [
     Proof("regif:fault_safe", "fv_umi_regif", "bmc",
           defines=("FV_REGIF_NOCHK",), params=(("SAFE", "1"),),
           expect="a_regif_outstanding"),
+
+    # ---- fv_umi_endpoint ----------------------------------------------
+    Proof("endpoint:fault_valid", "fv_umi_endpoint", "bmc",
+          defines=("FV_FAULT_VALID",), expect="RULE2_valid_hold"),
+    Proof("endpoint:fault_kind", "fv_umi_endpoint", "bmc",
+          defines=("FV_FAULT_KIND",), expect="a_ep_kind_wr"),
+    Proof("endpoint:fault_da", "fv_umi_endpoint", "bmc",
+          defines=("FV_FAULT_DA",), expect="a_ep_da"),
+    Proof("endpoint:fault_posted", "fv_umi_endpoint", "bmc",
+          defines=("FV_FAULT_POSTED",), expect="a_ep_outstanding"),
+    # nothing injected: the REG=1 arm really can hold two answers, so
+    # the REG=0 accounting law must fail there
+    Proof("endpoint:fault_cap", "fv_umi_endpoint", "bmc",
+          defines=("FV_EP_EXACT",), params=(("REG", "1"),),
+          expect="a_ep_outstanding"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
                       Endpoint, Fifo, Isolate, Memif, Monitor, Mux, Mux2,
-                      Pack, Pipeline, Regif, Stream, Unpack)
+                      Pack, Pipeline, RAM, Regif, Stream, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -128,6 +128,8 @@ FAMILIES = {
                          timeout=900),
     "fv_umi_endpoint": dict(deps=lambda: [Endpoint(), Checker()], depth=12,
                             timeout=900),
+    "fv_umi_ram": dict(deps=lambda: [RAM(), Checker()], depth=10,
+                       timeout=1800),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -164,9 +166,12 @@ class Proof:
 # sby names the label that broke the run on one of two engine lines:
 #   ##  0:00:00  Assert failed in <scope>: <label>
 #   ##  0:00:00  Unreached cover statement at <scope>: <label>
-# bmc/prove rows land on the first, cover rows on the second.
+# bmc/prove rows land on the first, cover rows on the second. A scope
+# inside a generate loop is printed as a Verilog escaped identifier,
+# which terminates with a SPACE -- "fv_umi_ram.\g_port[1].chk_resp :
+# RULE3_dstaddr_stable" -- so the separator is not always a bare colon.
 _FAIL_LABEL = re.compile(
-    r"(?:Assert failed in|Unreached cover statement at) \S+: (\w+)")
+    r"(?:Assert failed in|Unreached cover statement at) \S+\s*: (\w+)")
 
 
 def _failed_labels(log: str):
@@ -356,6 +361,20 @@ GREEN = [
     Proof("endpoint:bmc_reg", "fv_umi_endpoint", "bmc",
           params=(("REG", "1"),)),
     Proof("endpoint:cover", "fv_umi_endpoint", "cover"),
+
+    # ---- fv_umi_ram ---------------------------------------------------
+    # bounded: the memory array and the arbiter thermometer are both
+    # unobservable from these ports, so induction starts from states no
+    # trace reaches
+    # the response checker is lifted on the green rows: the block does
+    # not keep rule 3 on its response ports, which ram:fault_stable
+    # pins. a_ram_route is what this row proves
+    Proof("ram:bmc", "fv_umi_ram", "bmc", defines=("FV_RAM_NOCHK",)),
+    Proof("ram:cover", "fv_umi_ram", "cover", defines=("FV_RAM_NOCHK",)),
+    # the routing convention dropped: the two failures it holds off are
+    # behaviour of the shipped block, so they are witnessed not asserted
+    Proof("ram:hazard", "fv_umi_ram", "cover",
+          defines=("FV_RAM_NOCHK", "FV_RAM_ANYID")),
 
     # ---- configuration matrix -----------------------------------------
     # The harnesses above run one face each, chosen for solve time, and
@@ -552,6 +571,15 @@ FAULTS = [
     Proof("endpoint:fault_cap", "fv_umi_endpoint", "bmc",
           defines=("FV_EP_EXACT",), params=(("REG", "1"),),
           expect="a_ep_outstanding"),
+
+    # ---- fv_umi_ram ---------------------------------------------------
+    Proof("ram:fault_route", "fv_umi_ram", "bmc",
+          defines=("FV_RAM_NOCHK", "FV_FAULT_ROUTE"), expect="a_ram_route"),
+    # nothing injected: with the response checker in place the shipped
+    # block moves its broadcast response address while an answer is
+    # standing unaccepted. Pinned so the finding cannot regress
+    Proof("ram:fault_stable", "fv_umi_ram", "bmc",
+          expect="RULE3_dstaddr_stable"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -44,8 +44,8 @@ try:
 except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
-from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux, Mux,
-                      Mux2, Pack, Pipeline, Unpack)
+from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
+                      Isolate, Mux, Mux2, Pack, Pipeline, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -116,6 +116,7 @@ FAMILIES = {
     "fv_umi_pipeline": dict(deps=lambda: [Pipeline(), Checker()], depth=12,
                             timeout=300),
     "fv_umi_decode": dict(deps=lambda: [Decode()], depth=4, timeout=300),
+    "fv_umi_isolate": dict(deps=lambda: [Isolate()], depth=4, timeout=300),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -224,6 +225,14 @@ GREEN = [
     # hold and the covers pin what the four-bit compares admit
     Proof("decode:hazard", "fv_umi_decode", "cover",
           defines=("FV_DEC_ANYOPCODE",)),
+
+    # ---- fv_umi_isolate -----------------------------------------------
+    Proof("isolate:prove", "fv_umi_isolate", "prove"),
+    # the arm with the cells compiled out: a different circuit behind
+    # the same port list, so it gets judged rather than assumed
+    Proof("isolate:prove_iso0", "fv_umi_isolate", "prove",
+          params=(("ISO", "0"),)),
+    Proof("isolate:cover", "fv_umi_isolate", "cover"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:prove", "fv_umi_demux", "prove"),
@@ -376,6 +385,12 @@ FAULTS = [
           defines=("FV_FAULT_REQ",), expect="DEC_req_implies"),
     Proof("decode:fault_atomic", "fv_umi_decode", "bmc",
           defines=("FV_FAULT_ATOMIC",), expect="DEC_atomic_onehot0"),
+
+    # ---- fv_umi_isolate -----------------------------------------------
+    Proof("isolate:fault_pass", "fv_umi_isolate", "bmc",
+          defines=("FV_FAULT_PASS",), expect="a_iso_pass"),
+    Proof("isolate:fault_clamp", "fv_umi_isolate", "bmc",
+          defines=("FV_FAULT_CLAMP",), expect="a_iso_clamp"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -328,6 +328,36 @@ GREEN = [
     # closes over an arbitrary arbiter thermometer state
     Proof("crossbar:prove", "fv_umi_crossbar", "prove"),
     Proof("crossbar:cover", "fv_umi_crossbar", "cover"),
+
+    # ---- configuration matrix -----------------------------------------
+    # The harnesses above run one face each, chosen for solve time, and
+    # three of them (demux, mux2, crossbar) run AW=16/DW=32 -- narrower
+    # than README 4.1 permits, which is fine for a routing law but is
+    # not a configuration any UMI device ships. These rows re-answer the
+    # same questions at widths the specification allows and at the width
+    # nine blocks in this repo actually default to, so a truncation that
+    # only appears in a wide counter cannot hide behind a narrow proof.
+    Proof("buffer:prove_dw256", "fv_umi_buffer", "prove",
+          params=(("DW", "256"),)),
+    Proof("buffer:prove_aw32", "fv_umi_buffer", "prove",
+          params=(("AW", "32"),)),
+    Proof("demux:prove_legal", "fv_umi_demux", "prove",
+          params=(("AW", "64"), ("DW", "64"))),
+    Proof("mux2:prove_legal", "fv_umi_mux2", "prove",
+          params=(("AW", "64"), ("DW", "64"))),
+    Proof("crossbar:prove_legal", "fv_umi_crossbar", "prove",
+          params=(("AW", "64"), ("DW", "64"))),
+    Proof("pipeline:prove_dw256", "fv_umi_pipeline", "prove",
+          params=(("DW", "256"),)),
+    # the repo's own RAM testbench instantiates the arbiter at N=5; the
+    # proofs above stop at 4, and the thermometer is N-asymmetric
+    Proof("arbiter:prove_n5", "fv_umi_arbiter", "prove",
+          params=(("N", "5"),)),
+    # a widened face could pass vacuously if it made some assumption
+    # unsatisfiable, so one cover row rides the matrix: the environment
+    # must still reach every witness at the legal width
+    Proof("demux:cover_legal", "fv_umi_demux", "cover",
+          params=(("AW", "64"), ("DW", "64"))),
 ]
 
 FAULTS = [

--- a/tests/sumi/test_formal_sc.py
+++ b/tests/sumi/test_formal_sc.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover -- pre-formal-flow siliconcompiler
     _HAVE_SC_FORMAL = False
 
 from umi.sumi import (Arbiter, Buffer, Checker, Crossbar, Decode, Demux,
-                      Isolate, Mux, Mux2, Pack, Pipeline, Unpack)
+                      Isolate, Monitor, Mux, Mux2, Pack, Pipeline, Unpack)
 
 REPO = Path(__file__).resolve().parents[2]
 FORMAL_SUMI = REPO / "umi" / "formal" / "sumi"
@@ -117,6 +117,7 @@ FAMILIES = {
                             timeout=300),
     "fv_umi_decode": dict(deps=lambda: [Decode()], depth=4, timeout=300),
     "fv_umi_isolate": dict(deps=lambda: [Isolate()], depth=4, timeout=300),
+    "fv_umi_monitor": dict(deps=lambda: [Monitor()], depth=12, timeout=300),
     "fv_umi_cmd": dict(deps=lambda: [Checker()], depth=6, timeout=300),
     "fv_umi_txn": dict(deps=lambda: [Checker()], depth=20, timeout=1200),
 }
@@ -233,6 +234,10 @@ GREEN = [
     Proof("isolate:prove_iso0", "fv_umi_isolate", "prove",
           params=(("ISO", "0"),)),
     Proof("isolate:cover", "fv_umi_isolate", "cover"),
+
+    # ---- fv_umi_monitor -----------------------------------------------
+    Proof("monitor:prove", "fv_umi_monitor", "prove"),
+    Proof("monitor:cover", "fv_umi_monitor", "cover"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:prove", "fv_umi_demux", "prove"),
@@ -391,6 +396,10 @@ FAULTS = [
           defines=("FV_FAULT_PASS",), expect="a_iso_pass"),
     Proof("isolate:fault_clamp", "fv_umi_isolate", "bmc",
           defines=("FV_FAULT_CLAMP",), expect="a_iso_clamp"),
+
+    # ---- fv_umi_monitor -----------------------------------------------
+    Proof("monitor:fault_or", "fv_umi_monitor", "bmc",
+          defines=("FV_FAULT_OR",), expect="a_mon_beat"),
 
     # ---- fv_umi_demux -------------------------------------------------
     Proof("demux:fault_valid", "fv_umi_demux", "bmc", defines=("FV_FAULT_VALID",),

--- a/umi/formal/README.md
+++ b/umi/formal/README.md
@@ -28,7 +28,8 @@ table. This file is the index; the detail lives next to the code.
 
     pytest -m formal tests/sumi/test_formal_sc.py
 
-    # one row
+    # one family of rows -- -k is a substring match, so this selects the
+    # four buffer identity rows, not one
     pytest -m formal tests/sumi/test_formal_sc.py -k 'buffer:identity'
 
 To debug a proof under sby or yosys directly, run its row once with a pinned
@@ -106,7 +107,7 @@ verdict and not a label -- `buffer:fault_swap` injects the same corruption
 under `bmc` and pins the label there.
 
 There is no independent-solver corroboration here: every SMT result is gated on
-bitwuzla alone. Standing in its place is the fault matrix -- 54 rows that each
+bitwuzla alone. Standing in its place is the fault matrix -- 101 rows that each
 inject a bug and must each still produce a counterexample, which a solver
 quietly answering "proved" to everything would not deliver. To re-check one
 result against another solver, run its row, edit the `[engines]` line of the
@@ -146,10 +147,10 @@ job file it generated, and rerun that file by hand.
 | `sumi/fv_umi_codec` | `umi_pack` / `umi_unpack` | CMD codec round-trips over the 13 structured opcodes, and each field sits at the bit position `umi_messages.vh` defines | 2 | 1 |
 | `sumi/fv_umi_buffer` | `umi_buffer` | obeys the README 4.2 ready/valid handshake, including rule 5, and delivers every beat unchanged in all four SUMI fields and in accept order, with none dropped or invented | 13 | 11 |
 | `sumi/fv_umi_demux` | `umi_demux` | routing, broadcast and fork conservation; every output channel legal SUMI; rule 5 clean | 7 | 6 |
-| `sumi/fv_umi_arbiter` | `umi_arbiter` | grant contract: at most one grant, never to an idle or masked requester, and in priority mode the lowest unmasked requester wins | 6 | 4 |
+| `sumi/fv_umi_arbiter` | `umi_arbiter` | grant contract: at most one grant, never to an idle or masked requester, and in priority mode the lowest unmasked requester wins | 7 | 4 |
 | `sumi/fv_umi_mux` | `umi_mux` | merge identity at accept time: one accept in iff one accept out, and the output beat is the accepting input's (bounded) | 4 | 3 |
-| `sumi/fv_umi_mux2` | `umi_mux2` | select-and-merge: the output is the selected input's beat, accepts are conserved, and the output channel is legal SUMI under a stable select | 6 | 5 |
-| `sumi/fv_umi_crossbar` | `umi_crossbar` | NxN routing at accept time: one delivery per output, the delivered beat is the delivering input's, and no masked path delivers | 5 | 5 |
+| `sumi/fv_umi_mux2` | `umi_mux2` | select-and-merge: the output is the selected input's beat, accepts are conserved, and the output channel is legal SUMI under a stable select | 7 | 5 |
+| `sumi/fv_umi_crossbar` | `umi_crossbar` | NxN routing at accept time: one delivery per output, the delivered beat is the delivering input's, and no masked path delivers | 6 | 5 |
 | `sumi/fv_umi_pipeline` | `umi_pipeline` | the single-cycle register stage keeps the handshake and delivers every beat it accepts, once, in order, unchanged (unbounded -- every register is a port) | 9 | 6 |
 | `sumi/fv_umi_decode` | `umi_decode` | the class outputs are mutually exclusive and complete, and on the legal opcode set each matches the full five-bit encoding the four-bit compares stand in for | 3 | 4 |
 | `sumi/fv_umi_isolate` | `umi_isolate` | isolate high clamps the whole channel to zero and isolate low passes it through, over both build-time arms | 7 | 2 |
@@ -166,7 +167,7 @@ job file it generated, and rerun that file by hand.
 | `sumi/fv_umi_txn` | `umi_txn_checker` | response-side transaction / framing against a perfect in-order responder | 5 | 8 |
 | `sumi/fv_umi_frame` | `umi_frame_checker` | intra-message framing on a single channel, the request side included: the checker's assume face and assert face agree | 3 | 7 |
 
-110 green rows and 101 fault rows, 211 in all, over 22 harnesses.
+113 green rows and 101 fault rows, 214 in all, over 22 harnesses.
 
 Nineteen of them judge **shipped design RTL**, covering every SUMI block
 on a UMI path except `umi_memagent`, whose atomic unit is textually the

--- a/umi/formal/README.md
+++ b/umi/formal/README.md
@@ -144,27 +144,68 @@ job file it generated, and rerun that file by hand.
 | proof | judges | claim | green | fault |
 |---|---|---|---|---|
 | `sumi/fv_umi_codec` | `umi_pack` / `umi_unpack` | CMD codec round-trips over the 13 structured opcodes, and each field sits at the bit position `umi_messages.vh` defines | 2 | 1 |
-| `sumi/fv_umi_buffer` | `umi_buffer` | obeys the README 4.2 ready/valid handshake, including rule 5, and delivers every beat unchanged in all four SUMI fields and in accept order, with none dropped or invented | 9 | 11 |
-| `sumi/fv_umi_demux` | `umi_demux` | routing, broadcast and fork conservation; every output channel legal SUMI; rule 5 clean | 5 | 6 |
-| `sumi/fv_umi_arbiter` | `umi_arbiter` | grant contract: at most one grant, never to an idle or masked requester, and in priority mode the lowest unmasked requester wins | 5 | 4 |
+| `sumi/fv_umi_buffer` | `umi_buffer` | obeys the README 4.2 ready/valid handshake, including rule 5, and delivers every beat unchanged in all four SUMI fields and in accept order, with none dropped or invented | 11 | 11 |
+| `sumi/fv_umi_demux` | `umi_demux` | routing, broadcast and fork conservation; every output channel legal SUMI; rule 5 clean | 7 | 6 |
+| `sumi/fv_umi_arbiter` | `umi_arbiter` | grant contract: at most one grant, never to an idle or masked requester, and in priority mode the lowest unmasked requester wins | 6 | 4 |
 | `sumi/fv_umi_mux` | `umi_mux` | merge identity at accept time: one accept in iff one accept out, and the output beat is the accepting input's (bounded) | 2 | 3 |
-| `sumi/fv_umi_mux2` | `umi_mux2` | select-and-merge: the output is the selected input's beat, accepts are conserved, and the output channel is legal SUMI under a stable select | 3 | 5 |
-| `sumi/fv_umi_crossbar` | `umi_crossbar` | NxN routing at accept time: one delivery per output, the delivered beat is the delivering input's, and no masked path delivers | 2 | 5 |
+| `sumi/fv_umi_mux2` | `umi_mux2` | select-and-merge: the output is the selected input's beat, accepts are conserved, and the output channel is legal SUMI under a stable select | 4 | 5 |
+| `sumi/fv_umi_crossbar` | `umi_crossbar` | NxN routing at accept time: one delivery per output, the delivered beat is the delivering input's, and no masked path delivers | 3 | 5 |
+| `sumi/fv_umi_pipeline` | `umi_pipeline` | the single-cycle register stage keeps the handshake and delivers every beat it accepts, once, in order, unchanged (unbounded -- every register is a port) | 6 | 6 |
+| `sumi/fv_umi_decode` | `umi_decode` | the class outputs are mutually exclusive and complete, and on the legal opcode set each matches the full five-bit encoding the four-bit compares stand in for | 3 | 4 |
+| `sumi/fv_umi_isolate` | `umi_isolate` | isolate high clamps the whole channel to zero and isolate low passes it through, over both build-time arms | 3 | 2 |
+| `sumi/fv_umi_monitor` | `umi_monitor` | the passive tap reports a transfer on exactly the cycles README 4.2 rule 1 defines one | 2 | 1 |
+| `sumi/fv_umi_fifo` | `umi_fifo` | handshake and carriage over both the stored and bypass paths: nothing dropped, duplicated, invented or reordered (bounded, clocks tied) | 7 | 4 |
+| `sumi/fv_umi_stream` | `umi_stream` | a legal handshake on all four faces at once, the two UMI and the two USI (bounded, clocks tied) | 2 | 4 |
+| `sumi/fv_umi_memif` | `umi_memif` | the nine atomic operations against their arithmetic, and the arm that resolves an undefined ATYPE | 2 | 4 |
+| `sumi/fv_umi_regif` | `umi_regif` | the register interface answers the right kind of request and keeps the response handshake at `SAFE=0`; `SAFE=1` loses answers and is pinned | 3 | 4 |
+| `sumi/fv_umi_endpoint` | `umi_endpoint` | request to memory operation to response: one memory op per request, the right response kind, back to the requester, and the answers owed are accounted for | 3 | 5 |
+| `sumi/fv_umi_ram` | `umi_ram` | an answer is only offered to a port whose id bit it carries; the response channel's rule 3 failure is pinned (bounded) | 3 | 2 |
+| `sumi/fv_umi_fifoflex` | `umi_fifoflex` | bytes are conserved across a width change at `SPLIT=0` and on the merge arm; `SPLIT=1` is pinned as not conserving them (bounded) | 4 | 3 |
+| `sumi/fv_umi_switch` | `umi_switch` | the output handshake on every port, with the ready merge active across one and two outputs (bounded) | 4 | 1 |
 | `sumi/fv_umi_cmd` | `umi_cmd_checker` | CMD-word legality: the checker's assume face and assert face agree | 6 | 11 |
 | `sumi/fv_umi_txn` | `umi_txn_checker` | response-side transaction / framing against a perfect in-order responder | 5 | 8 |
 
-39 green rows and 54 fault rows, 93 in all.
+88 green rows and 94 fault rows, 182 in all, over 21 harnesses.
 
-`fv_umi_codec`, `fv_umi_buffer`, `fv_umi_demux`, `fv_umi_arbiter`,
-`fv_umi_mux`, `fv_umi_mux2` and `fv_umi_crossbar` judge **shipped design RTL**. `fv_umi_cmd` and `fv_umi_txn` qualify
+Nineteen of them judge **shipped design RTL**, covering every SUMI block
+on a UMI path except `umi_memagent`, whose atomic unit is textually the
+same as `umi_memif`'s but reaches no port without a memory round trip,
+and `umi_tester`, which is test-bench infrastructure rather than a block
+on a path. `fv_umi_cmd` and `fv_umi_txn` qualify
 the **checkers themselves**. `fv_umi_cmd` does so one face against the other;
 `fv_umi_txn` elaborates the asserting face alone, against a responder model, so
 its ASSUME face is not covered (see the scope note below).
+
+### Results that are pinned rather than proven
+
+Four blocks do not satisfy a law a reader would expect, and each has a
+row that REQUIRES the failure so it cannot regress into silence. Nothing
+is injected on any of them -- the shipped configuration is the subject:
+
+| row | what it requires to fail | why |
+|---|---|---|
+| `regif:fault_safe` | `a_regif_outstanding` | at `SAFE=1`, the default, a second request is accepted while the first answer still stands and the response is overwritten |
+| `endpoint:fault_cap` | `a_ep_outstanding` | the `REG=1` arm holds two answers, not one, so the `REG=0` accounting law does not carry over |
+| `ram:fault_stable` | `RULE3_dstaddr_stable` | the broadcast response address moves while an answer is standing unaccepted |
+| `fifoflex:fault_split` | `a_flex_conserve` | at `SPLIT=1`, the arm `umi_memagent` instantiates, more bytes are delivered than were accepted |
+
+If any of these ever goes green, the block changed and the lane says so.
 
 ### Scope notes
 
 Only the caveats a reader must know before trusting a result; full rationale
 is in each harness header.
+
+**Clocks are tied** in `fv_umi_fifo`, `fv_umi_stream` and `fv_umi_fifoflex`.
+Those blocks span two domains through `la_asyncfifo`; the harnesses drive both
+from one clock. That covers everything independent of the clock ratio and says
+nothing about true asynchrony, which needs a delay model on the synchroniser
+outputs that this directory does not have yet.
+
+**`umi_switch` is not re-exported** from `umi.sumi`, so the parametrized lint
+does not reach it and `fv_umi_switch` imports it directly. That keeps the
+existing decision to keep it out of the public API intact while still letting
+the block be judged.
 
 **README 4.2 rule 5** ("the assertion of VALID must not depend on the assertion
 of READY") is structural -- a cycle-sampled bind-in monitor cannot assert it.

--- a/umi/formal/README.md
+++ b/umi/formal/README.md
@@ -164,14 +164,15 @@ job file it generated, and rerun that file by hand.
 | `sumi/fv_umi_switch` | `umi_switch` | the output handshake on every port, with the ready merge active across one and two outputs (bounded) | 4 | 1 |
 | `sumi/fv_umi_cmd` | `umi_cmd_checker` | CMD-word legality: the checker's assume face and assert face agree | 6 | 11 |
 | `sumi/fv_umi_txn` | `umi_txn_checker` | response-side transaction / framing against a perfect in-order responder | 5 | 8 |
+| `sumi/fv_umi_frame` | `umi_frame_checker` | intra-message framing on a single channel, the request side included: the checker's assume face and assert face agree | 3 | 7 |
 
-88 green rows and 94 fault rows, 182 in all, over 21 harnesses.
+91 green rows and 101 fault rows, 192 in all, over 22 harnesses.
 
 Nineteen of them judge **shipped design RTL**, covering every SUMI block
 on a UMI path except `umi_memagent`, whose atomic unit is textually the
 same as `umi_memif`'s but reaches no port without a memory round trip,
 and `umi_tester`, which is test-bench infrastructure rather than a block
-on a path. `fv_umi_cmd` and `fv_umi_txn` qualify
+on a path. `fv_umi_cmd`, `fv_umi_txn` and `fv_umi_frame` qualify
 the **checkers themselves**. `fv_umi_cmd` does so one face against the other;
 `fv_umi_txn` elaborates the asserting face alone, against a responder model, so
 its ASSUME face is not covered (see the scope note below).

--- a/umi/formal/README.md
+++ b/umi/formal/README.md
@@ -144,20 +144,20 @@ job file it generated, and rerun that file by hand.
 | proof | judges | claim | green | fault |
 |---|---|---|---|---|
 | `sumi/fv_umi_codec` | `umi_pack` / `umi_unpack` | CMD codec round-trips over the 13 structured opcodes, and each field sits at the bit position `umi_messages.vh` defines | 2 | 1 |
-| `sumi/fv_umi_buffer` | `umi_buffer` | obeys the README 4.2 ready/valid handshake, including rule 5, and delivers every beat unchanged in all four SUMI fields and in accept order, with none dropped or invented | 11 | 11 |
+| `sumi/fv_umi_buffer` | `umi_buffer` | obeys the README 4.2 ready/valid handshake, including rule 5, and delivers every beat unchanged in all four SUMI fields and in accept order, with none dropped or invented | 13 | 11 |
 | `sumi/fv_umi_demux` | `umi_demux` | routing, broadcast and fork conservation; every output channel legal SUMI; rule 5 clean | 7 | 6 |
 | `sumi/fv_umi_arbiter` | `umi_arbiter` | grant contract: at most one grant, never to an idle or masked requester, and in priority mode the lowest unmasked requester wins | 6 | 4 |
-| `sumi/fv_umi_mux` | `umi_mux` | merge identity at accept time: one accept in iff one accept out, and the output beat is the accepting input's (bounded) | 2 | 3 |
-| `sumi/fv_umi_mux2` | `umi_mux2` | select-and-merge: the output is the selected input's beat, accepts are conserved, and the output channel is legal SUMI under a stable select | 4 | 5 |
-| `sumi/fv_umi_crossbar` | `umi_crossbar` | NxN routing at accept time: one delivery per output, the delivered beat is the delivering input's, and no masked path delivers | 3 | 5 |
-| `sumi/fv_umi_pipeline` | `umi_pipeline` | the single-cycle register stage keeps the handshake and delivers every beat it accepts, once, in order, unchanged (unbounded -- every register is a port) | 6 | 6 |
+| `sumi/fv_umi_mux` | `umi_mux` | merge identity at accept time: one accept in iff one accept out, and the output beat is the accepting input's (bounded) | 4 | 3 |
+| `sumi/fv_umi_mux2` | `umi_mux2` | select-and-merge: the output is the selected input's beat, accepts are conserved, and the output channel is legal SUMI under a stable select | 6 | 5 |
+| `sumi/fv_umi_crossbar` | `umi_crossbar` | NxN routing at accept time: one delivery per output, the delivered beat is the delivering input's, and no masked path delivers | 5 | 5 |
+| `sumi/fv_umi_pipeline` | `umi_pipeline` | the single-cycle register stage keeps the handshake and delivers every beat it accepts, once, in order, unchanged (unbounded -- every register is a port) | 9 | 6 |
 | `sumi/fv_umi_decode` | `umi_decode` | the class outputs are mutually exclusive and complete, and on the legal opcode set each matches the full five-bit encoding the four-bit compares stand in for | 3 | 4 |
-| `sumi/fv_umi_isolate` | `umi_isolate` | isolate high clamps the whole channel to zero and isolate low passes it through, over both build-time arms | 3 | 2 |
-| `sumi/fv_umi_monitor` | `umi_monitor` | the passive tap reports a transfer on exactly the cycles README 4.2 rule 1 defines one | 2 | 1 |
+| `sumi/fv_umi_isolate` | `umi_isolate` | isolate high clamps the whole channel to zero and isolate low passes it through, over both build-time arms | 7 | 2 |
+| `sumi/fv_umi_monitor` | `umi_monitor` | the passive tap reports a transfer on exactly the cycles README 4.2 rule 1 defines one | 4 | 1 |
 | `sumi/fv_umi_fifo` | `umi_fifo` | handshake and carriage over both the stored and bypass paths: nothing dropped, duplicated, invented or reordered (bounded, clocks tied) | 7 | 4 |
 | `sumi/fv_umi_stream` | `umi_stream` | a legal handshake on all four faces at once, the two UMI and the two USI (bounded, clocks tied) | 2 | 4 |
 | `sumi/fv_umi_memif` | `umi_memif` | the nine atomic operations against their arithmetic, and the arm that resolves an undefined ATYPE | 2 | 4 |
-| `sumi/fv_umi_regif` | `umi_regif` | the register interface answers the right kind of request and keeps the response handshake at `SAFE=0`; `SAFE=1` loses answers and is pinned | 3 | 4 |
+| `sumi/fv_umi_regif` | `umi_regif` | the register interface answers the right kind of request and keeps the response handshake at `SAFE=0`; `SAFE=1` loses answers and is pinned | 5 | 4 |
 | `sumi/fv_umi_endpoint` | `umi_endpoint` | request to memory operation to response: one memory op per request, the right response kind, back to the requester, and the answers owed are accounted for | 3 | 5 |
 | `sumi/fv_umi_ram` | `umi_ram` | an answer is only offered to a port whose id bit it carries; the response channel's rule 3 failure is pinned (bounded) | 3 | 2 |
 | `sumi/fv_umi_fifoflex` | `umi_fifoflex` | bytes are conserved across a width change at `SPLIT=0` and on the merge arm; `SPLIT=1` is pinned as not conserving them (bounded) | 4 | 3 |
@@ -166,7 +166,7 @@ job file it generated, and rerun that file by hand.
 | `sumi/fv_umi_txn` | `umi_txn_checker` | response-side transaction / framing against a perfect in-order responder | 5 | 8 |
 | `sumi/fv_umi_frame` | `umi_frame_checker` | intra-message framing on a single channel, the request side included: the checker's assume face and assert face agree | 3 | 7 |
 
-91 green rows and 101 fault rows, 192 in all, over 22 harnesses.
+110 green rows and 101 fault rows, 211 in all, over 22 harnesses.
 
 Nineteen of them judge **shipped design RTL**, covering every SUMI block
 on a UMI path except `umi_memagent`, whose atomic unit is textually the

--- a/umi/formal/sumi/fv_umi_arbiter.sv
+++ b/umi/formal/sumi/fv_umi_arbiter.sv
@@ -54,14 +54,11 @@
  * `~mask & requests`. That is what makes the lowest-index law
  * port-observable. The task assumes the mode for the whole trace.
  *
- * SCOPE NOTE -- the mode encoding. The port comment reads
- * "[00]=priority,[01]=roundrobin,[1x]=reserved" (umi_arbiter.v:29), but
- * the thermometer advances on `mode[1:0]==2'b10` (umi_arbiter.v:63), the
- * encoding that comment calls reserved. The documented round-robin mode
- * 2'b01 leaves the thermometer at zero, making it behave as priority.
- * This harness pins the encodings it proves rather than resolving the
- * discrepancy: `prio` uses 2'b00, and the rotation witness uses 2'b10
- * because that is where rotation actually happens.
+ * SCOPE NOTE -- the mode encoding. The thermometer advances only on
+ * `mode[1:0]==2'b10` (umi_arbiter.v:63), so 2'b10 is round-robin and
+ * every other encoding leaves the thermometer at zero and behaves as
+ * fixed priority. This harness pins the encoding on each row: `prio`
+ * uses 2'b00, and the rotation witness uses 2'b10.
  *
  * Fault rows corrupt only the OBSERVED grant vector, never the DUT, so
  * the proof must FAIL. A checker that cannot fail a broken design proves

--- a/umi/formal/sumi/fv_umi_decode.sv
+++ b/umi/formal/sumi/fv_umi_decode.sv
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves umi_decode classifies a command word the way README.md
+ *   section 3.2.3 and umi_messages.vh define it, and that the sixteen
+ *   class outputs it drives are mutually exclusive and complete.
+ *
+ * FIVE-BIT LAWS OVER FOUR-BIT COMPARES. umi_decode compares four bits
+ * for every structured class (umi_decode.v:75-91, e.g. command[3:0] ==
+ * UMI_REQ_READ[3:0]) while the opcodes it compares against are five-bit
+ * localparams. This harness asserts the five-bit equality instead:
+ *
+ *     DEC_read : cmd_read == (command[4:0] == UMI_REQ_READ)
+ *
+ * The two agree only because every legal structured opcode is below
+ * 5'h10, so bit 4 is zero across the legal set and the shorter compare
+ * decides it. The assumption that makes them agree is stated here and
+ * withdrawn in the hazard row, where the covers show what the shorter
+ * compare admits without it.
+ *
+ * STRUCTURAL LAWS, held for EVERY command word, legal or not:
+ *   DEC_class_onehot0   at most one of the sixteen class outputs is
+ *                       high. The thirteen structured classes take
+ *                       distinct nibbles, and the three full-byte
+ *                       classes (REQ_ERROR 0x0F, REQ_LINK 0x2F,
+ *                       RESP_LINK 0x0E) land on nibbles 0xF and 0xE
+ *                       that no structured class claims.
+ *   DEC_req_implies     every request class implies cmd_request
+ *   DEC_resp_implies    every response class implies cmd_response
+ *   DEC_reqresp_excl    cmd_request and cmd_response never agree
+ *   DEC_invalid_quiet   INVALID drives no class at all
+ *   DEC_atomic_onehot0  at most one atomic sub-operation
+ *   DEC_atomic_implies  every sub-operation implies cmd_atomic
+ *
+ * LEGAL-SET LAWS (the assumption above): the thirteen five-bit
+ * equalities, plus DEC_legal_complete -- on a legal non-INVALID word
+ * exactly one class fires, so the decoder has no holes.
+ *
+ * ATYPE OUTSIDE ADD..SWAP. Only 0x00-0x08 name an operation
+ * (umi_messages.vh:84-92), so a REQ_ATOMIC carrying ATYPE >= 9 sets
+ * cmd_atomic with no sub-operation selected. DEC_atomic_hole asserts
+ * that, c_dec_atomic_hole witnesses it is reachable. What a consumer
+ * does with an atomic naming no operation is the consumer's contract;
+ * no property here speaks to it.
+ *
+ * THE HAZARD ROW (decode:hazard, FV_DEC_ANYOPCODE). The legal-opcode
+ * assumption is dropped and the five-bit laws go with it. The
+ * structural laws still hold, and three covers pin the aliasing:
+ *   c_dec_alias_read    an opcode that is not REQ_READ decoding as a
+ *                       read (5'h11 is the smallest)
+ *   c_dec_alias_atomic  an opcode that is not REQ_ATOMIC decoding as an
+ *                       atomic (5'h19)
+ *   c_dec_alias_quiet   an illegal opcode decoding as no class at all
+ * The aliasing is behaviour of the shipped RTL, not a fault this
+ * harness injects.
+ *
+ * Purely combinational, so induction closes immediately; the value of
+ * prove mode is the quantifier over all 2^CW command words.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   decode:prove          all laws over the legal set, unbounded
+ *   decode:cover          witnesses: expect all reached
+ *   decode:hazard         legal assumption dropped, aliasing witnessed
+ *   decode:fault_read     must FAIL, DEC_read
+ *   decode:fault_onehot   must FAIL, DEC_class_onehot0
+ *   decode:fault_req      must FAIL, DEC_req_implies
+ *   decode:fault_atomic   must FAIL, DEC_atomic_onehot0
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_decode #(
+    parameter CW = 32
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    // ----------------------------------------------------------------
+    // one free command word
+    // ----------------------------------------------------------------
+    (* anyseq *) wire [CW-1:0] command;
+
+    wire [4:0] opcode5 = command[4:0];
+    wire [7:0] opcode8 = command[7:0];
+    wire [7:0] atype   = command[15:8];
+
+    // the thirteen structured opcodes (requests odd, responses even)
+    wire f_structured =
+        (opcode5 == UMI_REQ_READ)     | (opcode5 == UMI_REQ_WRITE)    |
+        (opcode5 == UMI_REQ_POSTED)   | (opcode5 == UMI_REQ_RDMA)     |
+        (opcode5 == UMI_REQ_ATOMIC)   | (opcode5 == UMI_REQ_USER0)    |
+        (opcode5 == UMI_REQ_FUTURE0)  |
+        (opcode5 == UMI_RESP_READ)    | (opcode5 == UMI_RESP_WRITE)   |
+        (opcode5 == UMI_RESP_USER0)   | (opcode5 == UMI_RESP_USER1)   |
+        (opcode5 == UMI_RESP_FUTURE0) | (opcode5 == UMI_RESP_FUTURE1);
+
+    // the three that redefine the whole byte
+    wire f_fullbyte =
+        (opcode8 == UMI_REQ_ERROR) | (opcode8 == UMI_REQ_LINK) |
+        (opcode8 == UMI_RESP_LINK);
+
+    wire f_invalid = (opcode8 == UMI_INVALID);
+
+    // structured opcodes carry SIZE in command[7:5], so only the low
+    // five bits are pinned here; the full-byte three pin all eight
+    wire f_legal = f_structured | f_fullbyte | f_invalid;
+
+`ifndef FV_DEC_ANYOPCODE
+    always @(*) begin
+        legal_opcode : assume (f_legal);
+    end
+`endif
+
+    // ----------------------------------------------------------------
+    // the decoder
+    // ----------------------------------------------------------------
+    wire cmd_invalid;
+    wire cmd_request, cmd_response;
+    wire cmd_read, cmd_write, cmd_write_posted, cmd_rdma, cmd_atomic;
+    wire cmd_user0, cmd_future0, cmd_error, cmd_link;
+    wire cmd_read_resp, cmd_write_resp, cmd_user0_resp, cmd_user1_resp;
+    wire cmd_future0_resp, cmd_future1_resp, cmd_link_resp;
+    wire cmd_atomic_add, cmd_atomic_and, cmd_atomic_or, cmd_atomic_xor;
+    wire cmd_atomic_max, cmd_atomic_min, cmd_atomic_maxu, cmd_atomic_minu;
+    wire cmd_atomic_swap;
+
+    umi_decode #(.CW (CW)) dut (
+        .command          (command),
+        .cmd_invalid      (cmd_invalid),
+        .cmd_request      (cmd_request),
+        .cmd_response     (cmd_response),
+        .cmd_read         (cmd_read),
+        .cmd_write        (cmd_write),
+        .cmd_write_posted (cmd_write_posted),
+        .cmd_rdma         (cmd_rdma),
+        .cmd_atomic       (cmd_atomic),
+        .cmd_user0        (cmd_user0),
+        .cmd_future0      (cmd_future0),
+        .cmd_error        (cmd_error),
+        .cmd_link         (cmd_link),
+        .cmd_read_resp    (cmd_read_resp),
+        .cmd_write_resp   (cmd_write_resp),
+        .cmd_user0_resp   (cmd_user0_resp),
+        .cmd_user1_resp   (cmd_user1_resp),
+        .cmd_future0_resp (cmd_future0_resp),
+        .cmd_future1_resp (cmd_future1_resp),
+        .cmd_link_resp    (cmd_link_resp),
+        .cmd_atomic_add   (cmd_atomic_add),
+        .cmd_atomic_and   (cmd_atomic_and),
+        .cmd_atomic_or    (cmd_atomic_or),
+        .cmd_atomic_xor   (cmd_atomic_xor),
+        .cmd_atomic_max   (cmd_atomic_max),
+        .cmd_atomic_min   (cmd_atomic_min),
+        .cmd_atomic_maxu  (cmd_atomic_maxu),
+        .cmd_atomic_minu  (cmd_atomic_minu),
+        .cmd_atomic_swap  (cmd_atomic_swap)
+    );
+
+    // ----------------------------------------------------------------
+    // observed outputs: the faults corrupt what the laws see, never the
+    // DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_READ
+    wire obs_read = cmd_read ^ f_glitch;
+`else
+    wire obs_read = cmd_read;
+`endif
+
+`ifdef FV_FAULT_ONEHOT
+    // a second class asserted alongside the first
+    wire obs_write = cmd_write | (cmd_read & f_glitch);
+`else
+    wire obs_write = cmd_write;
+`endif
+
+`ifdef FV_FAULT_REQ
+    // the request flag withdrawn under a request class
+    wire obs_request = cmd_request & ~f_glitch;
+`else
+    wire obs_request = cmd_request;
+`endif
+
+`ifdef FV_FAULT_ATOMIC
+    // two sub-operations selected at once
+    wire obs_atomic_or = cmd_atomic_or | (cmd_atomic_add & f_glitch);
+`else
+    wire obs_atomic_or = cmd_atomic_or;
+`endif
+
+    // ----------------------------------------------------------------
+    // class vectors
+    // ----------------------------------------------------------------
+    wire [15:0] class_vec = {
+        obs_read, obs_write, cmd_write_posted, cmd_rdma,
+        cmd_atomic, cmd_user0, cmd_future0, cmd_error,
+        cmd_link, cmd_read_resp, cmd_write_resp, cmd_user0_resp,
+        cmd_user1_resp, cmd_future0_resp, cmd_future1_resp, cmd_link_resp
+    };
+
+    wire [8:0] atomic_vec = {
+        cmd_atomic_add, cmd_atomic_and, obs_atomic_or, cmd_atomic_xor,
+        cmd_atomic_max, cmd_atomic_min, cmd_atomic_maxu, cmd_atomic_minu,
+        cmd_atomic_swap
+    };
+
+    wire any_request = obs_read | obs_write | cmd_write_posted | cmd_rdma
+                     | cmd_atomic | cmd_user0 | cmd_future0 | cmd_error
+                     | cmd_link;
+
+    wire any_response = cmd_read_resp | cmd_write_resp | cmd_user0_resp
+                      | cmd_user1_resp | cmd_future0_resp | cmd_future1_resp
+                      | cmd_link_resp;
+
+    // ----------------------------------------------------------------
+    // structural laws: every command word, legal or not
+    // ----------------------------------------------------------------
+    always @(*) begin
+        // at most one class: x & (x-1) clears the lowest set bit, so a
+        // zero result means at most one bit was set
+        DEC_class_onehot0 : assert ((class_vec & (class_vec - 16'd1))
+                                    == 16'd0);
+        DEC_atomic_onehot0 : assert ((atomic_vec & (atomic_vec - 9'd1))
+                                     == 9'd0);
+        DEC_req_implies : assert (!any_request  || obs_request);
+        DEC_resp_implies : assert (!any_response || cmd_response);
+        DEC_reqresp_excl : assert (!(obs_request & cmd_response));
+        DEC_invalid_quiet : assert (!cmd_invalid || (class_vec == 16'd0));
+        DEC_atomic_implies : assert ((atomic_vec == 9'd0) || cmd_atomic);
+        // an atomic naming an operation outside ADD..SWAP selects none
+        DEC_atomic_hole : assert (!cmd_atomic || (atype <= 8'h08)
+                                  || (atomic_vec == 9'd0));
+    end
+
+    // ----------------------------------------------------------------
+    // legal-set laws: the full five-bit opcode equality the four-bit
+    // compares are standing in for
+    // ----------------------------------------------------------------
+`ifndef FV_DEC_ANYOPCODE
+    always @(*) begin
+        DEC_read : assert (obs_read == (opcode5 == UMI_REQ_READ));
+        DEC_write : assert (obs_write == (opcode5 == UMI_REQ_WRITE));
+        DEC_posted : assert (cmd_write_posted == (opcode5 == UMI_REQ_POSTED));
+        DEC_rdma : assert (cmd_rdma == (opcode5 == UMI_REQ_RDMA));
+        DEC_atomic : assert (cmd_atomic == (opcode5 == UMI_REQ_ATOMIC));
+        DEC_user0 : assert (cmd_user0 == (opcode5 == UMI_REQ_USER0));
+        DEC_future0 : assert (cmd_future0 == (opcode5 == UMI_REQ_FUTURE0));
+        DEC_read_resp : assert (cmd_read_resp == (opcode5 == UMI_RESP_READ));
+        DEC_write_resp : assert (cmd_write_resp == (opcode5 == UMI_RESP_WRITE));
+        DEC_user0_resp : assert (cmd_user0_resp == (opcode5 == UMI_RESP_USER0));
+        DEC_user1_resp : assert (cmd_user1_resp == (opcode5 == UMI_RESP_USER1));
+        DEC_future0_resp : assert (cmd_future0_resp
+                                   == (opcode5 == UMI_RESP_FUTURE0));
+        DEC_future1_resp : assert (cmd_future1_resp
+                                   == (opcode5 == UMI_RESP_FUTURE1));
+        // no holes: a legal word that is not INVALID lands on exactly
+        // one class
+        DEC_legal_complete : assert (cmd_invalid || (class_vec != 16'd0));
+    end
+`endif
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(*) begin
+        c_dec_read : cover (cmd_read);
+        c_dec_write_resp : cover (cmd_write_resp);
+        c_dec_link : cover (cmd_link);
+        c_dec_error : cover (cmd_error);
+        c_dec_invalid : cover (cmd_invalid);
+        c_dec_atomic_swap : cover (cmd_atomic_swap);
+        // a REQ_ATOMIC naming no operation: reachable, and nothing
+        // downstream of the decoder is told which way to resolve it
+        c_dec_atomic_hole : cover (cmd_atomic & (atomic_vec == 9'd0));
+    end
+
+ `ifdef FV_DEC_ANYOPCODE
+    // the aliasing the four-bit compares admit once the legal-opcode
+    // assumption is withdrawn
+    always @(*) begin
+        c_dec_alias_read : cover (cmd_read & (opcode5 != UMI_REQ_READ));
+        c_dec_alias_atomic : cover (cmd_atomic & (opcode5 != UMI_REQ_ATOMIC));
+        c_dec_alias_quiet : cover (!f_legal & (class_vec == 16'd0)
+                                   & !cmd_invalid);
+    end
+ `endif
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_endpoint.sv
+++ b/umi/formal/sumi/fv_umi_endpoint.sv
@@ -1,0 +1,439 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves umi_endpoint turns a UMI request into the right local memory
+ *   operation, answers it with the right response, and keeps the SUMI
+ *   handshake on the response channel while doing so.
+ *
+ * THE LAWS.
+ *   RULE2_valid_hold / RULE3_*_stable  the response channel, with the
+ *                     request channel constrained legal by the same
+ *                     checker in its ASSUME face
+ *   a_ep_mem_onehot0  loc_read, loc_write and loc_atomic never overlap:
+ *                     one request drives at most one kind of memory
+ *                     operation
+ *   a_ep_kind         a read or an atomic is answered RESP_READ, a
+ *                     write RESP_WRITE (README 3.4.11, 3.4.12, and the
+ *                     RESP_READ-for-atomics rule in 3.4.6)
+ *   a_ep_da           the response goes back to the requester: response
+ *                     DSTADDR is the SRCADDR of the request that caused
+ *                     it (README 3.3.1)
+ *   a_ep_sa           and its SRCADDR is that request's DSTADDR
+ *   a_ep_outstanding  (REG=0, unbounded) the answers owed are exactly
+ *                     what VALID advertises. This is also what enforces
+ *                     README 3.4.4: a posted write is not a question,
+ *                     so answering one pushes delivered past asked, the
+ *                     difference wraps, and the law catches it
+ *   a_ep_capacity     (REG=1, bounded) that arm holds two answers and
+ *                     only one is a port, so it states capacity, with
+ *                     a_ep_backed adding that a standing answer is
+ *                     always backed by a request
+ *
+ * WHAT THE HARNESS READS, AND FROM WHERE. Everything above is taken off
+ * ports. The request beat is udev_req_valid & udev_req_ready, both
+ * ports. The kind of request is decoded from udev_req_cmd[4:0] against
+ * the localparams in umi_messages.vh -- that is the specification's own
+ * encoding, not a copy of the block's decoder, and fv_umi_decode
+ * already proves umi_decode agrees with it across the legal opcode set.
+ * The request is assumed to carry a legal opcode (m_ep_legal) for the
+ * same reason fv_umi_decode assumes it: outside that set the four-bit
+ * compares inside umi_decode alias, and this harness is not the place
+ * that question is asked.
+ *
+ * WHY THERE IS NO OVERWRITE HERE. umi_regif has a configuration that
+ * takes a second request while the first answer still stands
+ * (see fv_umi_regif). umi_endpoint cannot: request_stall
+ * (umi_endpoint.v:286-288) folds udev_resp_ready back into
+ * udev_req_ready, so a standing unaccepted answer stops the request
+ * side outright. The accounting laws are what say so, on both arms --
+ * nothing is ever answered that was not asked, and nothing asked is
+ * dropped to make room.
+ *
+ * A cycle-local "a posted write leaves the response side quiet" law was
+ * written first and removed. It is wrong on REG=1 -- an answer already
+ * in the pipeline stage can surface a cycle after a posted beat, with
+ * nothing amiss -- and on REG=0 it says nothing the accounting law does
+ * not already say. Two reasons to drop it, and neither is visible
+ * without running it.
+ *
+ * The register-side outputs that are single assigns off the request
+ * word -- loc_addr, loc_wrdata -- are not asserted against their own
+ * expressions, which would be the code read back. What is asserted
+ * about the memory side is the part that is not a restatement:
+ * a_ep_mem_onehot0.
+ *
+ * Outside these laws: the memory behind loc_*, error propagation, the
+ * atomic arithmetic (that is fv_umi_memif), and multi-beat requests --
+ * the harness holds LEN at zero, so every request here is one beat.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   endpoint:prove         REG=0, all laws, unbounded
+ *   endpoint:bmc_reg       REG=1, BOUNDED -- the second answer sits in
+ *                          a pipeline stage no port shows, so the exact
+ *                          count is not expressible and a bare bound on
+ *                          wrapping counters does not close by induction
+ *   endpoint:cover         witnesses: expect all reached
+ *   endpoint:fault_valid   must FAIL, chk_resp.RULE2_valid_hold
+ *   endpoint:fault_kind    must FAIL, a_ep_kind_wr (the xor swaps
+ *                          the two response opcodes, so either half
+ *                          of the kind law can catch it)
+ *   endpoint:fault_da      must FAIL, a_ep_da
+ *   endpoint:fault_posted  must FAIL, a_ep_outstanding -- a posted
+ *                          write given a reply
+ *   endpoint:fault_cap     REG=1 with the REG=0 accounting law forced
+ *                          on -- must FAIL, a_ep_outstanding. Nothing
+ *                          is injected: the two arms really do hold
+ *                          different numbers of answers, and this row
+ *                          keeps that written down
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_endpoint #(
+    parameter REG = 0,
+    parameter CW  = 32,
+    parameter AW  = 64,
+    parameter DW  = 64,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus
+    // ----------------------------------------------------------------
+    (* anyseq *) wire          req_valid;
+    (* anyseq *) wire [CW-1:0] req_cmd;
+    (* anyseq *) wire [AW-1:0] req_dstaddr;
+    (* anyseq *) wire [AW-1:0] req_srcaddr;
+    (* anyseq *) wire [DW-1:0] req_data;
+    (* anyseq *) wire          resp_ready;
+    (* anyseq *) wire [DW-1:0] loc_rddata;
+    (* anyseq *) wire          loc_ready;
+
+    wire          req_ready;
+    wire          resp_valid;
+    wire [CW-1:0] resp_cmd;
+    wire [AW-1:0] resp_dstaddr;
+    wire [AW-1:0] resp_srcaddr;
+    wire [DW-1:0] resp_data;
+    wire [AW-1:0] loc_addr;
+    wire          loc_write;
+    wire          loc_read;
+    wire          loc_atomic;
+    wire [7:0]    loc_opcode;
+    wire [2:0]    loc_size;
+    wire [7:0]    loc_len;
+    wire [7:0]    loc_atype;
+    wire [DW-1:0] loc_wrdata;
+
+    // ----------------------------------------------------------------
+    // the request, decoded from the specification's own encoding
+    // ----------------------------------------------------------------
+    wire [4:0] req_opcode = req_cmd[4:0];
+    wire cmd_read   = (req_opcode == UMI_REQ_READ);
+    wire cmd_write  = (req_opcode == UMI_REQ_WRITE);
+    wire cmd_posted = (req_opcode == UMI_REQ_POSTED);
+    wire cmd_atomic = (req_opcode == UMI_REQ_ATOMIC);
+
+    // the five request kinds this block acts on, plus INVALID so the
+    // quiet case is explored. Outside the legal set umi_decode's
+    // four-bit compares alias, which is fv_umi_decode's question.
+    wire req_legal = cmd_read | cmd_write | cmd_posted | cmd_atomic
+                   | (req_cmd[7:0] == UMI_INVALID);
+
+    always @(*) begin
+        m_ep_legal : assume (req_legal);
+        // one beat per request: multi-beat framing is the transaction
+        // checker's subject, not this block's
+        m_ep_single : assume (req_cmd[UMI_LEN_MSB:UMI_LEN_LSB] == 8'd0);
+    end
+
+    umi_endpoint #(
+        .REG (REG), .CW (CW), .AW (AW), .DW (DW)
+    ) dut (
+        .nreset           (nreset),
+        .clk              (clk),
+        .udev_req_valid   (req_valid),
+        .udev_req_cmd     (req_cmd),
+        .udev_req_dstaddr (req_dstaddr),
+        .udev_req_srcaddr (req_srcaddr),
+        .udev_req_data    (req_data),
+        .udev_req_ready   (req_ready),
+        .udev_resp_valid  (resp_valid),
+        .udev_resp_cmd    (resp_cmd),
+        .udev_resp_dstaddr(resp_dstaddr),
+        .udev_resp_srcaddr(resp_srcaddr),
+        .udev_resp_data   (resp_data),
+        .udev_resp_ready  (resp_ready),
+        .loc_addr         (loc_addr),
+        .loc_write        (loc_write),
+        .loc_read         (loc_read),
+        .loc_atomic       (loc_atomic),
+        .loc_opcode       (loc_opcode),
+        .loc_size         (loc_size),
+        .loc_len          (loc_len),
+        .loc_atype        (loc_atype),
+        .loc_wrdata       (loc_wrdata),
+        .loc_rddata       (loc_rddata),
+        .loc_ready        (loc_ready)
+    );
+
+    // ----------------------------------------------------------------
+    // observed response: the faults corrupt what the laws see, never
+    // the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+    // Two separate observation paths, so a fault can reach only the law
+    // it is aimed at. obs_valid is what the handshake checker sees;
+    // acct_valid is what the accounting and the field laws see. Sharing
+    // one wire made the VALID fault convict a_ep_sa -- the dropped
+    // beats put the answer counter out of step, so the tracked answer
+    // pointed at the wrong response long before rule 2 was reached.
+`ifdef FV_FAULT_VALID
+    wire obs_valid = resp_valid & ~f_glitch;
+`else
+    wire obs_valid = resp_valid;
+`endif
+
+`ifdef FV_FAULT_POSTED
+    // a posted write answered anyway
+    reg posted_q;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            posted_q <= 1'b0;
+        else
+            posted_q <= req_valid & req_ready & cmd_posted & f_glitch;
+    wire acct_valid = resp_valid | posted_q;
+`else
+    wire acct_valid = resp_valid;
+`endif
+
+`ifdef FV_FAULT_KIND
+    // RESP_READ 0x02 and RESP_WRITE 0x04 differ by 0x06, so one
+    // constant xor swaps them. Constant on purpose -- a per-cycle flip
+    // would move the payload under a standing offer and convict rule 3
+    // before reaching the law this row is aimed at.
+    wire [CW-1:0] obs_cmd = resp_cmd ^ {{(CW-5){1'b0}}, 5'b00110};
+`else
+    wire [CW-1:0] obs_cmd = resp_cmd;
+`endif
+
+`ifdef FV_FAULT_DA
+    // the answer sent somewhere other than back to the requester
+    wire [AW-1:0] obs_dstaddr = ~resp_dstaddr;
+`else
+    wire [AW-1:0] obs_dstaddr = resp_dstaddr;
+`endif
+
+    // ----------------------------------------------------------------
+    // the two channels
+    // ----------------------------------------------------------------
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (1),                      // environment: assume legal input
+        .RULE_EN (RULE_EN)
+    ) env_req (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (req_valid),
+        .ready   (req_ready),
+        .cmd     (req_cmd),
+        .dstaddr (req_dstaddr),
+        .srcaddr (req_srcaddr),
+        .data    (req_data)
+    );
+
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (0),                      // requirement: assert legal output
+        .RULE_EN (RULE_EN)
+    ) chk_resp (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (obs_valid),
+        .ready   (resp_ready),
+        .cmd     (obs_cmd),
+        .dstaddr (obs_dstaddr),
+        .srcaddr (resp_srcaddr),
+        .data    (resp_data)
+    );
+
+    // ----------------------------------------------------------------
+    // the request being answered
+    // ----------------------------------------------------------------
+    wire beat     = req_valid & req_ready;
+    wire responds = cmd_read | cmd_write | cmd_atomic;
+
+    // Requests that call for an answer, and answers delivered, both
+    // numbered. A single "most recent request" shadow is NOT enough
+    // here: the REG=1 arm holds two answers at once, so the newest
+    // request does not describe the answer currently being offered.
+    // One arbitrary number is tracked instead -- the solver picks it,
+    // so proving the tracked answer proves every answer -- which is
+    // depth-independent and covers both arms with one set of laws.
+    localparam KW = 5;
+    localparam CAPACITY = 1 + REG;   // response slots on this arm
+    reg [KW-1:0] asked;
+    reg [KW-1:0] answered;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            asked    <= {KW{1'b0}};
+            answered <= {KW{1'b0}};
+        end else begin
+            if (beat & responds)
+                asked <= asked + {{(KW-1){1'b0}}, 1'b1};
+            if (acct_valid & resp_ready)
+                answered <= answered + {{(KW-1){1'b0}}, 1'b1};
+        end
+
+    wire [KW-1:0] outstanding = asked - answered;
+
+    (* anyconst *) wire [KW-1:0] fv_answer;
+    reg          exp_read;
+    reg          exp_write;
+    reg [AW-1:0] exp_da;
+    reg [AW-1:0] exp_sa;
+    always @(posedge clk)
+        if (beat & responds & (asked == fv_answer)) begin
+            // an atomic is answered as a read (README 3.4.6)
+            exp_read  <= cmd_read | cmd_atomic;
+            exp_write <= cmd_write;
+            exp_da    <= req_srcaddr;   // back to the requester
+            exp_sa    <= req_dstaddr;
+        end
+
+    // the answer now being offered carries number `answered`
+    wire tracked = (answered == fv_answer);
+
+    // ----------------------------------------------------------------
+    // the laws
+    // ----------------------------------------------------------------
+    always @(*) begin
+        // one request, at most one kind of memory operation
+        a_ep_mem_onehot0 : assert (({2'b0, loc_read}
+                                  + {2'b0, loc_write}
+                                  + {2'b0, loc_atomic}) <= 3'd1);
+    end
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            if (acct_valid & tracked & exp_read)
+                a_ep_kind : assert (obs_cmd[4:0] == UMI_RESP_READ);
+            if (acct_valid & tracked & exp_write & ~exp_read)
+                a_ep_kind_wr : assert (obs_cmd[4:0] == UMI_RESP_WRITE);
+            if (acct_valid & tracked) begin
+                a_ep_da : assert (obs_dstaddr == exp_da);
+                a_ep_sa : assert (resp_srcaddr == exp_sa);
+            end
+        end
+
+    // How many answers the block may hold at once, and it is not the
+    // same number on both arms. REG=0 has one response slot, so the
+    // count is exactly what VALID advertises. REG=1 adds a pipeline
+    // stage (umi_endpoint.v:290-307) and can hold two -- one in the
+    // stage, one behind it -- and only the outer one is a port, so the
+    // exact form is not expressible there and the law states capacity
+    // instead. This was not predicted: the exact law was written for
+    // both arms and REG=1 failed its base case with a real two-deep
+    // trace.
+`ifdef FV_EP_EXACT
+    // the REG=0 law forced on regardless of arm: on REG=1 it must fail,
+    // and the row that requires it to is what stops the two arms
+    // quietly becoming one
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset)
+            a_ep_outstanding : assert (outstanding
+                                       == {{(KW-1){1'b0}}, acct_valid});
+`else
+    generate
+        if (REG == 0) begin : g_ep_exact
+            // One response slot, and it is a port, so the count can be
+            // pinned exactly -- which is also what makes it inductive.
+            // An answer nobody asked for (a posted write given a reply)
+            // pushes delivered past asked, the difference wraps, and
+            // this catches it.
+            always @(posedge clk)
+                if (f_past_exists & nreset & past_nreset)
+                    a_ep_outstanding : assert (outstanding
+                                               == {{(KW-1){1'b0}},
+                                                   acct_valid});
+        end else begin : g_ep_pipe
+            // REG=1 holds two answers -- one in the pipeline stage, one
+            // behind it -- and only the outer one is a port. The exact
+            // count is therefore not expressible here, and a bare bound
+            // on wrapping counters is not inductive: the step case may
+            // start from any pair of counter values. So this arm is
+            // BOUNDED, and its row says so.
+            always @(posedge clk)
+                if (f_past_exists & nreset & past_nreset) begin
+                    a_ep_capacity : assert (outstanding
+                                            <= CAPACITY[KW-1:0]);
+                    a_ep_backed   : assert (~acct_valid
+                                            || (outstanding != {KW{1'b0}}));
+                end
+        end
+    endgenerate
+`endif
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_ep_read    : cover (acct_valid & tracked & exp_read);
+            c_ep_write   : cover (acct_valid & tracked & exp_write
+                                  & ~exp_read);
+            // the tracked answer really is delivered, so the field laws
+            // are not passing on an answer that never came
+            c_ep_deliver : cover (acct_valid & resp_ready & tracked);
+            c_ep_xfer    : cover (obs_valid & resp_ready);
+            c_ep_wait    : cover (obs_valid & ~resp_ready);
+            c_ep_bp      : cover (~req_ready);
+            c_ep_memrd   : cover (loc_read);
+            c_ep_memwr   : cover (loc_write);
+            c_ep_atomic  : cover (loc_atomic);
+            // a posted write really does reach memory without an answer
+            c_ep_posted  : cover (beat & cmd_posted & loc_write);
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_fifo.sv
+++ b/umi/formal/sumi/fv_umi_fifo.sv
@@ -1,0 +1,368 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves umi_fifo keeps the SUMI handshake (README.md section 4.2
+ *   rules 2 and 3) and carries every beat it accepts through in order,
+ *   over both of its paths: the stored path (BYPASS=0) and the
+ *   combinational bypass (BYPASS=1).
+ *
+ * ONE CLOCK. THIS IS THE SCOPE, AND IT IS A REAL LIMIT. umi_fifo is a
+ * dual-clock block: it wraps la_asyncfifo, whose read and write
+ * pointers cross between the two domains through gray coding and
+ * la_drsync synchronisers. This harness ties umi_in_clk to umi_out_clk
+ * and umi_in_nreset to umi_out_nreset and proves the block in that one
+ * configuration.
+ *
+ * What that buys: every bug that does not depend on the clock ratio --
+ * pointer arithmetic, full and empty derivation, the datapath, the
+ * bypass multiplexers, ordering.
+ *
+ * What it does NOT buy, and no row here should be read as claiming:
+ * anything about true asynchrony. Metastability is not in the Verilog
+ * semantics at all, so a synchroniser proves nothing against silicon
+ * until the properties are re-run against a model that lets the synced
+ * value arrive a cycle late. That model does not exist in this
+ * directory yet. Until it does, umi_fifo is judged single-clock, and
+ * the async behaviour is unverified rather than verified.
+ *
+ * BOUNDED, NOT UNBOUNDED. These rows run bmc. The pointers reach
+ * la_drsync registers that no port shows, so k-induction starts its
+ * step case from pointer states that disagree with the beats actually
+ * in the memory, and reports a violation no trace can reach. The same
+ * fence umi_buffer met at its skid register and fv_umi_mux meets at its
+ * captured input. umi_buffer got past it with abc pdr; that engine does
+ * not converge on this block at these widths inside the lane's
+ * timeout, so the honest result is a bounded one and it is labelled
+ * bounded.
+ *
+ * WIDTHS. CW=32, AW=32, DW=64 -- the narrowest face the specification
+ * actually permits (README 4.1: CW is 32, AW is 32 or 64, DW starts at
+ * 64). The laws are width-agnostic because the datapath is
+ * bit-parallel and carried as one vector.
+ *
+ * DEPTH. The handshake rows run the block default of 4. The carriage
+ * rows pin DEPTH=2, the smallest depth that still fills, wraps its
+ * pointers and drains, because the bounded search cost grows with the
+ * stored state: the same rows at DEPTH=4 take eight times as long for
+ * a law that does not mention DEPTH. Sweeping it belongs with the rest
+ * of the configuration matrix, not in every run of the lane.
+ *
+ * LAWS.
+ *   RULE2_valid_hold / RULE3_*_stable   the handshake at the output,
+ *                     with the input constrained to be legal by the
+ *                     same checker in its ASSUME face
+ *   a_fifo_no_overflow  beats accepted and not yet delivered never
+ *                     exceed DEPTH, so nothing is written over
+ *   a_fifo_no_underflow  a beat is never delivered while the block is
+ *                     holding none, so nothing is invented
+ *   a_fifo_beat       the beat delivered with a given number is the
+ *                     beat accepted with that number, whole: CMD,
+ *                     DSTADDR, SRCADDR and DATA compared as one
+ *                     vector. Order rides along, because the number IS
+ *                     the accept order
+ *
+ * The two counting laws are inequalities on purpose. rd_empty is
+ * derived from a pointer that has crossed a synchroniser, so it lags
+ * the true occupancy even with the clocks tied; an equality against it
+ * would be asserting the lag away.
+ *
+ * chaosmode is declared by umi_fifo and never read (its only
+ * appearance is the port declaration), so it is tied low here and no
+ * property depends on it.
+ *
+ * Outside these laws: progress (nothing here says an accepted beat is
+ * ever delivered -- this file asserts no liveness property), clock
+ * ratios, and reset skew between the two domains.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   fifo:bmc              handshake, stored path, bounded
+ *   fifo:bmc_bypass       handshake, bypass path, bounded
+ *   fifo:cover            witnesses: expect all reached
+ *   fifo:identity         the three carriage laws, stored path, DEPTH=2
+ *   fifo:identity_bypass  the same labels over the bypass path, which
+ *                         stores nothing, so they collapse to a
+ *                         cycle-local pair (see g_id_bypass)
+ *   fifo:identity_cover   the tracked beat is really delivered, the
+ *                         memory really fills, so no law passes
+ *                         vacuously
+ *   fifo:identity_cover_bypass  the same job for the bypass arm
+ *   fifo:fault_valid      must FAIL, chk_out.RULE2_valid_hold
+ *   fifo:fault_data       must FAIL, chk_out.RULE3_data_stable
+ *   fifo:fault_swap       must FAIL, a_fifo_beat
+ *   fifo:fault_ghost      must FAIL, a_fifo_no_underflow
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_fifo #(
+    parameter CW     = 32,
+    parameter AW     = 32,
+    parameter DW     = 64,
+    parameter DEPTH  = 4,
+    parameter BYPASS = 0,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+    localparam PW = CW + AW + AW + DW;   // packed SUMI packet
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus (constrained only by the rules, via env_in below)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire          in_valid;
+    (* anyseq *) wire [CW-1:0] in_cmd;
+    (* anyseq *) wire [AW-1:0] in_dstaddr;
+    (* anyseq *) wire [AW-1:0] in_srcaddr;
+    (* anyseq *) wire [DW-1:0] in_data;
+    (* anyseq *) wire          out_ready;
+
+    wire          in_ready;
+    wire          out_valid;
+    wire [CW-1:0] out_cmd;
+    wire [AW-1:0] out_dstaddr;
+    wire [AW-1:0] out_srcaddr;
+    wire [DW-1:0] out_data;
+    wire          fifo_full;
+    wire          fifo_almost_full;
+    wire          fifo_empty;
+
+    wire [PW-1:0] in_packet = {in_cmd, in_dstaddr, in_srcaddr, in_data};
+
+    // both domains driven from the one clock and reset: see ONE CLOCK
+    umi_fifo #(
+        .DEPTH (DEPTH), .CW (CW), .AW (AW), .DW (DW)
+    ) dut (
+        .bypass           (BYPASS[0]),
+        .chaosmode        (1'b0),
+        .fifo_full        (fifo_full),
+        .fifo_almost_full (fifo_almost_full),
+        .fifo_empty       (fifo_empty),
+        .umi_in_clk       (clk),
+        .umi_in_nreset    (nreset),
+        .umi_in_valid     (in_valid),
+        .umi_in_cmd       (in_cmd),
+        .umi_in_dstaddr   (in_dstaddr),
+        .umi_in_srcaddr   (in_srcaddr),
+        .umi_in_data      (in_data),
+        .umi_in_ready     (in_ready),
+        .umi_out_clk      (clk),
+        .umi_out_nreset   (nreset),
+        .umi_out_valid    (out_valid),
+        .umi_out_cmd      (out_cmd),
+        .umi_out_dstaddr  (out_dstaddr),
+        .umi_out_srcaddr  (out_srcaddr),
+        .umi_out_data     (out_data),
+        .umi_out_ready    (out_ready),
+        .vdd              (1'b1),
+        .vss              (1'b0)
+    );
+
+    // ----------------------------------------------------------------
+    // observed output channel: the faults corrupt what the checker and
+    // the carriage laws see, never the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+    (* anyseq *) wire f_ghost;
+
+`ifdef FV_FAULT_VALID
+    // an offer withdrawn without being accepted: rule 2
+    wire obs_valid = out_valid & ~f_glitch;
+`elsif FV_FAULT_GHOST
+    // a beat the block never accepted, offered anyway. Made a LEGAL
+    // offer -- it rises out of reset and changes only on a cycle the
+    // receiver accepts -- so the handshake rules still hold and only
+    // the accounting law can report it.
+    reg ghost_q;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            ghost_q <= 1'b0;
+        else if (out_ready)
+            ghost_q <= f_ghost;
+    wire obs_valid = out_valid | ghost_q;
+`else
+    wire obs_valid = out_valid;
+`endif
+
+`ifdef FV_FAULT_DATA
+    // payload moving underneath a standing offer: rule 3
+    wire [DW-1:0] obs_data = out_data ^ {DW{f_glitch}};
+`else
+    wire [DW-1:0] obs_data = out_data;
+`endif
+
+`ifdef FV_FAULT_SWAP
+    // the two addresses exchanged: every handshake rule still holds --
+    // the swap is stable and the timing untouched -- and only the
+    // carriage law can see it
+    wire [AW-1:0] obs_dstaddr = out_srcaddr;
+    wire [AW-1:0] obs_srcaddr = out_dstaddr;
+`else
+    wire [AW-1:0] obs_dstaddr = out_dstaddr;
+    wire [AW-1:0] obs_srcaddr = out_srcaddr;
+`endif
+
+    wire [PW-1:0] obs_packet = {out_cmd, obs_dstaddr, obs_srcaddr, obs_data};
+
+    // ----------------------------------------------------------------
+    // the handshake, both faces of one rule list
+    // ----------------------------------------------------------------
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (1),                      // environment: assume legal input
+        .RULE_EN (RULE_EN)
+    ) env_in (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (in_valid),
+        .ready   (in_ready),
+        .cmd     (in_cmd),
+        .dstaddr (in_dstaddr),
+        .srcaddr (in_srcaddr),
+        .data    (in_data)
+    );
+
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (0),                      // requirement: assert legal output
+        .RULE_EN (RULE_EN)
+    ) chk_out (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (obs_valid),
+        .ready   (out_ready),
+        .cmd     (out_cmd),
+        .dstaddr (obs_dstaddr),
+        .srcaddr (obs_srcaddr),
+        .data    (obs_data)
+    );
+
+    // ----------------------------------------------------------------
+    // carriage: nothing dropped, duplicated, invented or reordered
+    //
+    // Kept off the handshake rows on purpose: the accounting laws read
+    // the same obs_valid the handshake faults corrupt and would report
+    // a cycle ahead of the rule those rows are aimed at.
+    // ----------------------------------------------------------------
+`ifdef FV_IDENTITY
+    wire insert = in_valid  & in_ready;    // accepted at the input
+    wire remove = obs_valid & out_ready;   // delivered at the output
+
+    localparam IW = 4;                     // beat numbers, modulo 16
+
+    reg [IW-1:0] in_cnt;
+    reg [IW-1:0] out_cnt;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            in_cnt  <= {IW{1'b0}};
+            out_cnt <= {IW{1'b0}};
+        end else begin
+            if (insert)
+                in_cnt  <= in_cnt  + {{(IW-1){1'b0}}, 1'b1};
+            if (remove)
+                out_cnt <= out_cnt + {{(IW-1){1'b0}}, 1'b1};
+        end
+
+    // ONE arbitrary beat number, constant for the whole trace. The
+    // solver picks it, so proving the tracked beat proves every beat.
+    (* anyconst *) wire [IW-1:0] fv_beat;
+    reg [PW-1:0] tracked;
+    always @(posedge clk)
+        if (insert && (in_cnt == fv_beat))
+            tracked <= in_packet;
+
+    wire [IW-1:0] occ = in_cnt - out_cnt;
+
+    generate
+        if (BYPASS == 0) begin : g_id_stored
+            always @(posedge clk)
+                if (f_past_exists & nreset & past_nreset) begin
+                    a_fifo_no_overflow  : assert (occ <= DEPTH[IW-1:0]);
+                    a_fifo_no_underflow : assert (!remove
+                                                  || (occ != {IW{1'b0}}));
+                    if (remove && (out_cnt == fv_beat))
+                        a_fifo_beat : assert (obs_packet == tracked);
+                end
+
+            // witnesses: no carriage law is passing on an idle link
+            always @(posedge clk)
+                if (f_past_exists & nreset & past_nreset) begin
+                    c_fifo_deliver : cover (remove && (out_cnt == fv_beat));
+                    c_fifo_b2b     : cover (insert && remove);
+                    // the memory really fills, so the capacity law is
+                    // not passing on a link that never queued anything
+                    c_fifo_full    : cover (occ == DEPTH[IW-1:0]);
+                end
+
+        end else begin : g_id_bypass
+            // the bypass path stores nothing: the output IS the input,
+            // so a delivery and an acceptance are the same event and
+            // the two accounting laws collapse. Same labels, same
+            // claims -- capacity, then no invention, then payload.
+            always @(posedge clk)
+                if (f_past_exists & nreset & past_nreset) begin
+                    a_fifo_no_overflow  : assert (occ == {IW{1'b0}});
+                    a_fifo_no_underflow : assert (insert == remove);
+                    if (obs_valid)
+                        a_fifo_beat : assert (obs_packet == in_packet);
+                end
+
+            always @(posedge clk)
+                if (f_past_exists & nreset & past_nreset) begin
+                    c_fifo_deliver : cover (insert && remove);
+                    // an offer standing unaccepted -- the case
+                    // a_fifo_beat covers that a delivery would not reach
+                    c_fifo_b2b     : cover (obs_valid && !out_ready);
+                end
+        end
+    endgenerate
+`endif
+
+    // ----------------------------------------------------------------
+    // handshake witnesses: live on every row, so no proof passes over
+    // a link that never moves a beat or never stalls
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_fifo_xfer  : cover (obs_valid & out_ready);
+            c_fifo_wait  : cover (obs_valid & ~out_ready);
+            c_fifo_bp    : cover (~in_ready);
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_fifoflex.sv
+++ b/umi/formal/sumi/fv_umi_fifoflex.sv
@@ -1,0 +1,340 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves umi_fifoflex neither invents nor loses payload while it
+ *   changes the width of a UMI stream, and keeps the SUMI handshake on
+ *   both faces while doing it.
+ *
+ * WHAT A WIDTH CONVERTER CAN GET WRONG. Every other carriage proof in
+ * this directory tracks a beat: the beat that went in is the beat that
+ * comes out. That question does not survive a width change -- one beat
+ * in is not one beat out, so there is no beat to track. What is
+ * conserved is BYTES, and that is what these rows count:
+ *
+ *   a_flex_conserve  bytes delivered never exceed bytes accepted, so
+ *                    nothing is invented
+ *   a_flex_bounded   bytes accepted and not yet delivered stay within
+ *                    the storage the block actually has, so nothing
+ *                    silently piles up
+ *
+ * Bytes come from the command word the specification defines them in:
+ * (LEN+1) << SIZE, per README 3.3.2 and 3.3.3, computed the same way on
+ * both faces from CW fields alone. Nothing in the DUT is copied to do
+ * it.
+ *
+ * BOUNDED, AND NOT BY ACCIDENT. These are bmc rows. A conservation law
+ * written over running counters is not inductive: the counters wrap, so
+ * the step case may start with delivered already ahead of accepted and
+ * the induction fails while the base case passes. The exact in-flight
+ * figure would close it, but it lives in latch_bytes and the packet
+ * latch (umi_fifoflex.v:271-287), neither of which is a port. Bounded
+ * is the honest answer here and the rows say so.
+ *
+ * THE BLOCK'S OWN LIMITS, ASSUMED RATHER THAN TRIPPED OVER. The header
+ * of umi_fifoflex records two things it does not handle, and a harness
+ * that ignored them would be reporting the block for doing what it
+ * says it does:
+ *   - SIZE larger than the output width is out of scope, because the
+ *     block does not manipulate SIZE (umi_fifoflex.v:25). m_flex_size
+ *     keeps SIZE within the narrower of the two faces.
+ *   - a beat is only merged when the merged result does not cross the
+ *     output boundary (umi_fifoflex.v:26-27). m_flex_cap keeps each
+ *     input beat inside one input word, which is the condition the
+ *     block is built for.
+ * Both are stated here so a reader can see the shape of the claim
+ * rather than infer it.
+ *
+ * WHAT HOLDS, AND WHAT DOES NOT. The block is three circuits behind one
+ * port list (umi_fifoflex.v:263, :410, :462), and they do not all keep
+ * the law:
+ *
+ *   SPLIT=0, IDW == ODW   conservation holds. This is fifoflex:bmc.
+ *   IDW  < ODW  (merge)   conservation holds with the splitter on.
+ *                         This is fifoflex:bmc_merge.
+ *   SPLIT=1               conservation FAILS. fifoflex:fault_split
+ *                         requires it to, with nothing injected: the
+ *                         block delivers more bytes than it was given,
+ *                         because one latched packet is offered and
+ *                         accepted more than once. umi_memagent
+ *                         instantiates umi_fifoflex with SPLIT=1
+ *                         (umi_memagent.v:63-70), so this is the arm in
+ *                         use, not a corner nobody builds.
+ *
+ * THE LENGTH ARITHMETIC IS UNSIGNED. Separately from the above, the
+ * split arm computes a beat length as
+ *
+ *     ((ODW/8 - byte_offset) >> SIZE) - 1        (umi_fifoflex.v:429-431)
+ *
+ * with no guard on the subtraction. An address whose offset leaves
+ * fewer than one SIZE-sized word inside the output word makes the shift
+ * yield zero, and the minus one wraps to 255 -- a beat announcing 256
+ * words. Such an address is not aligned, so README 3.3.1 already rules
+ * it out and m_flex_align assumes it away on the proving rows; the
+ * hazard row withdraws that assumption and c_flex_lenblow reaches the
+ * wrap. Written down because the guard is one comparison and the
+ * failure is silent.
+ *
+ * Outside these laws: which bytes come out in which order (the byte
+ * count does not see a permutation), the async arm (ASYNC=0
+ * throughout -- see fv_umi_fifo for why a synchroniser needs a delay
+ * model before it means anything), and progress.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   fifoflex:bmc          SPLIT=0, IDW == ODW, bounded
+ *   fifoflex:bmc_merge    IDW  < ODW, bounded
+ *   fifoflex:cover        witnesses: expect all reached
+ *   fifoflex:hazard       alignment withdrawn; c_flex_lenblow reaches
+ *                         the unsigned wrap in the length arithmetic
+ *   fifoflex:fault_valid  must FAIL, chk_out.RULE2_valid_hold
+ *   fifoflex:fault_invent must FAIL, a_flex_conserve (injected)
+ *   fifoflex:fault_split  must FAIL, a_flex_conserve -- SPLIT=1, and
+ *                         nothing is injected
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_fifoflex #(
+    parameter CW    = 32,
+    parameter AW    = 64,
+    parameter IDW   = 64,
+    parameter ODW   = 64,
+    parameter DEPTH = 2,
+    parameter SPLIT = 1,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    // the narrower face decides how much one beat may carry
+    localparam MINDW  = (IDW < ODW) ? IDW : ODW;
+    localparam MINSZ  = $clog2(MINDW/8);      // largest in-range SIZE
+    localparam INCAP  = IDW / 8;              // bytes in one input word
+    localparam BW     = 12;                   // byte counters, modulo 4096
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus
+    // ----------------------------------------------------------------
+    (* anyseq *) wire           in_valid;
+    (* anyseq *) wire [CW-1:0]  in_cmd;
+    (* anyseq *) wire [AW-1:0]  in_dstaddr;
+    (* anyseq *) wire [AW-1:0]  in_srcaddr;
+    (* anyseq *) wire [IDW-1:0] in_data;
+    (* anyseq *) wire           out_ready;
+
+    wire           in_ready;
+    wire           out_valid;
+    wire [CW-1:0]  out_cmd;
+    wire [AW-1:0]  out_dstaddr;
+    wire [AW-1:0]  out_srcaddr;
+    wire [ODW-1:0] out_data;
+    wire           fifo_full;
+    wire           fifo_empty;
+
+    umi_fifoflex #(
+        .ASYNC (0), .SPLIT (SPLIT), .DEPTH (DEPTH),
+        .CW (CW), .AW (AW), .IDW (IDW), .ODW (ODW)
+    ) dut (
+        .bypass          (1'b0),
+        .chaosmode       (1'b0),
+        .fifo_full       (fifo_full),
+        .fifo_empty      (fifo_empty),
+        .umi_in_clk      (clk),
+        .umi_in_nreset   (nreset),
+        .umi_in_valid    (in_valid),
+        .umi_in_cmd      (in_cmd),
+        .umi_in_dstaddr  (in_dstaddr),
+        .umi_in_srcaddr  (in_srcaddr),
+        .umi_in_data     (in_data),
+        .umi_in_ready    (in_ready),
+        .umi_out_clk     (clk),
+        .umi_out_nreset  (nreset),
+        .umi_out_valid   (out_valid),
+        .umi_out_cmd     (out_cmd),
+        .umi_out_dstaddr (out_dstaddr),
+        .umi_out_srcaddr (out_srcaddr),
+        .umi_out_data    (out_data),
+        .umi_out_ready   (out_ready),
+        .vdd             (1'b1),
+        .vss             (1'b0)
+    );
+
+    // ----------------------------------------------------------------
+    // bytes, from the command word the specification defines them in
+    // ----------------------------------------------------------------
+    wire [7:0] in_len   = in_cmd[UMI_LEN_MSB:UMI_LEN_LSB];
+    wire [2:0] in_size  = in_cmd[UMI_SIZE_MSB:UMI_SIZE_LSB];
+    wire [7:0] out_len  = out_cmd[UMI_LEN_MSB:UMI_LEN_LSB];
+    wire [2:0] out_size = out_cmd[UMI_SIZE_MSB:UMI_SIZE_LSB];
+
+    wire [BW-1:0] in_bytes  = ({{(BW-8){1'b0}}, in_len}  + {{(BW-1){1'b0}}, 1'b1})
+                              << in_size;
+    wire [BW-1:0] out_bytes = ({{(BW-8){1'b0}}, out_len} + {{(BW-1){1'b0}}, 1'b1})
+                              << out_size;
+
+    // the block's own stated limits: SIZE inside the narrower face, and
+    // one input beat inside one input word. See THE BLOCK'S OWN LIMITS.
+    // DA aligned to SIZE, README 3.3.1 -- the same rule
+    // umi_cmd_checker enforces as CMD4_da_aligned
+    wire [AW-1:0] align_mask = ({{(AW-1){1'b0}}, 1'b1} << in_size)
+                             - {{(AW-1){1'b0}}, 1'b1};
+
+    always @(*) begin
+        m_flex_size : assume (in_size <= MINSZ[2:0]);
+        m_flex_cap  : assume (in_bytes <= INCAP[BW-1:0]);
+        m_flex_some : assume (in_bytes != {BW{1'b0}});
+`ifndef FV_FLEX_NOALIGN
+        m_flex_align : assume ((in_dstaddr & align_mask) == {AW{1'b0}});
+`endif
+    end
+
+    // ----------------------------------------------------------------
+    // observed output: the faults corrupt what the laws see, never the
+    // DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_VALID
+    wire obs_valid = out_valid & ~f_glitch;
+`else
+    wire obs_valid = out_valid;
+`endif
+
+`ifdef FV_FAULT_INVENT
+    // one extra byte claimed on every delivered beat
+    wire [BW-1:0] obs_bytes = out_bytes + {{(BW-1){1'b0}}, 1'b1};
+`else
+    wire [BW-1:0] obs_bytes = out_bytes;
+`endif
+
+    // ----------------------------------------------------------------
+    // the handshake, both faces of one rule list
+    // ----------------------------------------------------------------
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (IDW),
+        .ASSUME (1),                      // environment: assume legal input
+        .RULE_EN (RULE_EN)
+    ) env_in (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (in_valid),
+        .ready   (in_ready),
+        .cmd     (in_cmd),
+        .dstaddr (in_dstaddr),
+        .srcaddr (in_srcaddr),
+        .data    (in_data)
+    );
+
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (ODW),
+        .ASSUME (0),                      // requirement: assert legal output
+        .RULE_EN (RULE_EN)
+    ) chk_out (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (obs_valid),
+        .ready   (out_ready),
+        .cmd     (out_cmd),
+        .dstaddr (out_dstaddr),
+        .srcaddr (out_srcaddr),
+        .data    (out_data)
+    );
+
+    // ----------------------------------------------------------------
+    // byte accounting
+    // ----------------------------------------------------------------
+    wire insert = in_valid  & in_ready;
+    wire remove = obs_valid & out_ready;
+
+    reg [BW-1:0] taken;
+    reg [BW-1:0] given;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            taken <= {BW{1'b0}};
+            given <= {BW{1'b0}};
+        end else begin
+            if (insert)
+                taken <= taken + in_bytes;
+            if (remove)
+                given <= given + obs_bytes;
+        end
+
+    // what the block can be holding: the packet latch plus the fifo,
+    // each at most one input word wide
+    localparam [BW-1:0] HOLD = (DEPTH + 2) * INCAP;
+
+`ifndef FV_FLEX_NOALIGN
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            a_flex_conserve : assert (given <= taken);
+            a_flex_bounded  : assert ((taken - given) <= HOLD);
+        end
+`endif
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_flex_in    : cover (insert);
+            c_flex_out   : cover (remove);
+            c_flex_wait  : cover (obs_valid & ~out_ready);
+            c_flex_bp    : cover (~in_ready);
+            // payload really does cross, so the laws are not passing on
+            // an idle link
+            c_flex_move  : cover (given != {BW{1'b0}});
+            // and a conversion really happens: a delivered beat that
+            // does not carry the same byte count as the one taken
+            c_flex_convert : cover (remove & (obs_bytes != in_bytes));
+        end
+
+ `ifdef FV_FLEX_NOALIGN
+    // Alignment withdrawn. The split arm computes the beat length as
+    //   ((ODW/8 - byte_offset) >> SIZE) - 1        (umi_fifoflex.v:429-431)
+    // and that subtraction is unsigned. An address whose offset leaves
+    // fewer than one SIZE-word inside the output word makes the shift
+    // yield zero, so the minus one wraps to 255 and the block emits a
+    // beat claiming 256 words. c_flex_lenblow reaches it.
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset)
+            c_flex_lenblow : cover (remove & (obs_bytes > INCAP[BW-1:0]));
+ `endif
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_frame.sv
+++ b/umi/formal/sumi/fv_umi_frame.sv
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Qualifies umi_frame_checker the way fv_umi_cmd qualifies
+ *   umi_cmd_checker: one face of the checker against the other. A free
+ *   channel is driven through an ASSUME instance, so every beat that
+ *   reaches the ASSERT instance is framed the way the rule list says a
+ *   message is framed. If the two faces agree, prove closes; if a rule
+ *   were written differently on one side, this harness reports it.
+ *
+ * WHY THIS MATTERS FOR A CHECKER RATHER THAN A BLOCK. There is no
+ * design RTL under test here. What is under test is the module a
+ * fabric would bind to its REQUEST ports -- the half umi_txn_checker's
+ * header records as missing, since it asserts framing on responses only
+ * and a host emitting broken multi-beat requests passes everything.
+ * A checker nobody has qualified is not evidence, so it gets the same
+ * treatment as the other two.
+ *
+ * THE FAULT ROWS ARE THE POINT. Six rules, and one row per rule that
+ * breaks exactly that rule on the observed channel while the driving
+ * channel stays legal. Each must FAIL on its own label, so no rule can
+ * be quietly vacuous:
+ *
+ *   frame:fault_size    SIZE changed mid-message      FRAME_size_stable
+ *   frame:fault_opcode  opcode changed mid-message    FRAME_opcode_stable
+ *   frame:fault_fields  QOS moved mid-message         FRAME_fields_stable
+ *   frame:fault_da      DA off the running address    FRAME_da_cont
+ *   frame:fault_sa      SA off the running address    FRAME_sa_cont
+ *   frame:fault_bytes   message over the ceiling      FRAME_msgbytes
+ *
+ * The corruptions are applied to the command and address words the
+ * asserting instance sees, never to the assuming one, so the two faces
+ * genuinely disagree rather than both being bent the same way.
+ *
+ * BOUNDED. FRAME_msgbytes accumulates bytes across a message, and a free
+ * accumulator in the step case can start above the ceiling, so that one
+ * rule does not close by induction. The other five are cycle-local
+ * comparisons and would; the row is bounded because the weakest rule on
+ * it is, and that is stated rather than split into two rows for a
+ * better-looking label.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   frame:bmc            the two faces agree, bounded
+ *   frame:cover          witnesses: expect all reached, including a
+ *                        multi-beat message opening, continuing and
+ *                        closing on both faces
+ *   frame:bmc_mask_off   RULE_EN=0 over a fully free observed channel:
+ *                        with the mask cleared nothing is reported. The
+ *                        fault_mask_da row is the other half
+ *   frame:fault_*        six rows, one per rule, listed above
+ *   frame:fault_mask_da  RULE_EN with only bit 3 set, so FRAME_da_cont alone can
+ *                        report -- the mask is falsifiable, not
+ *                        decorative
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_frame #(
+    parameter CW = 32,
+    parameter AW = 64,
+    parameter DW = 64,
+    parameter [31:0] MAX_MSG_BYTES = 32768,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    // ----------------------------------------------------------------
+    // one free channel
+    // ----------------------------------------------------------------
+    (* anyseq *) wire          valid;
+    (* anyseq *) wire          ready;
+    (* anyseq *) wire [CW-1:0] cmd;
+    (* anyseq *) wire [AW-1:0] dstaddr;
+    (* anyseq *) wire [AW-1:0] srcaddr;
+    (* anyseq *) wire [DW-1:0] data;
+
+    // keep the beats inside a sane envelope: SIZE within the data word
+    // and a byte count that fits, so the arithmetic under test is the
+    // framing and not an out-of-range transfer
+    wire [2:0] size = cmd[UMI_SIZE_MSB:UMI_SIZE_LSB];
+    always @(*) begin
+        m_frame_size : assume (size <= 3'd3);
+        m_frame_len  : assume (cmd[UMI_LEN_MSB:UMI_LEN_LSB] <= 8'd3);
+    end
+
+    // ----------------------------------------------------------------
+    // the driving face: every beat that gets past here is legally framed
+    // ----------------------------------------------------------------
+    umi_frame_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .MAX_MSG_BYTES (MAX_MSG_BYTES),
+        .ASSUME (1),
+        .RULE_EN (6'h3F)
+    ) env_frm (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (valid),
+        .ready   (ready),
+        .cmd     (cmd),
+        .dstaddr (dstaddr),
+        .srcaddr (srcaddr),
+        .data    (data)
+    );
+
+    // ----------------------------------------------------------------
+    // the observed channel: each fault bends exactly one rule, and only
+    // on this side, so the two faces genuinely disagree
+    // ----------------------------------------------------------------
+    // A stability rule compares a continuation beat against the FIRST
+    // beat of its message. Corrupting every beat the same way leaves
+    // them agreeing -- the first beat carries the corruption into
+    // first_cmd -- and the rule holds. That is how the first version of
+    // these rows passed while proving nothing. The corruption is gated
+    // on a continuation beat instead, tracked here from the port
+    // signals rather than reached for inside the checker.
+    reg h_open;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            h_open <= 1'b0;
+        else if (valid & ready)
+            h_open <= ~cmd[UMI_EOM_BIT];
+
+    wire bend = h_open;          // this beat continues an open message
+
+`ifdef FV_FAULT_SIZE
+    wire [CW-1:0] obs_cmd = cmd ^ (bend ? (32'd1 << UMI_SIZE_LSB) : 32'd0);
+`elsif FV_FAULT_OPCODE
+    wire [CW-1:0] obs_cmd = cmd ^ (bend ? (32'd1 << UMI_OPCODE_LSB) : 32'd0);
+`elsif FV_FAULT_FIELDS
+    wire [CW-1:0] obs_cmd = cmd ^ (bend ? (32'd1 << UMI_QOS_LSB) : 32'd0);
+`else
+    wire [CW-1:0] obs_cmd = cmd;
+`endif
+
+`ifdef FV_FAULT_DA
+    wire [AW-1:0] obs_dstaddr = dstaddr ^ {{(AW-1){1'b0}}, 1'b1};
+`else
+    wire [AW-1:0] obs_dstaddr = dstaddr;
+`endif
+
+`ifdef FV_FAULT_SA
+    wire [AW-1:0] obs_srcaddr = srcaddr ^ {{(AW-1){1'b0}}, 1'b1};
+`else
+    wire [AW-1:0] obs_srcaddr = srcaddr;
+`endif
+
+`ifdef FV_FAULT_FREEOUT
+    // the observed channel entirely free: with the mask open every rule
+    // is breakable, so a single enabled bit names the rule reported
+    (* anyseq *) wire [CW-1:0] free_cmd;
+    (* anyseq *) wire [AW-1:0] free_dstaddr;
+    (* anyseq *) wire [AW-1:0] free_srcaddr;
+    umi_frame_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .MAX_MSG_BYTES (MAX_MSG_BYTES),
+        .ASSUME (0),
+        .RULE_EN (RULE_EN)
+    ) chk_frm (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (valid),
+        .ready   (ready),
+        .cmd     (free_cmd),
+        .dstaddr (free_dstaddr),
+        .srcaddr (free_srcaddr),
+        .data    (data)
+    );
+`else
+    // The byte-ceiling row is a PARAMETER mismatch, not a corrupted
+    // signal: the asserting face is given a lower ceiling than the
+    // driving face, so a perfectly legal long message crosses it and
+    // FRAME_msgbytes is the only rule that can report. Bending a signal to reach
+    // the ceiling breaks the address laws a cycle sooner.
+`ifdef FV_FAULT_BYTES
+    localparam [31:0] CHK_MAX = 32'd64;
+`else
+    localparam [31:0] CHK_MAX = MAX_MSG_BYTES;
+`endif
+
+    umi_frame_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .MAX_MSG_BYTES (CHK_MAX),
+        .ASSUME (0),
+        .RULE_EN (RULE_EN)
+    ) chk_frm (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (valid),
+        .ready   (ready),
+        .cmd     (obs_cmd),
+        .dstaddr (obs_dstaddr),
+        .srcaddr (obs_srcaddr),
+        .data    (data)
+    );
+`endif
+
+    // ----------------------------------------------------------------
+    // witnesses: a multi-beat message really is exercised, so the rules
+    // are not passing on single-beat traffic that never opens a message
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    wire beat = valid & ready;
+    always @(posedge clk)
+        if (f_past_exists & nreset) begin
+            c_frame_single : cover (beat & cmd[UMI_EOM_BIT]);
+            c_frame_open   : cover (beat & ~cmd[UMI_EOM_BIT]);
+            c_frame_stall  : cover (valid & ~ready);
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_isolate.sv
+++ b/umi/formal/sumi/fv_umi_isolate.sv
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves the power-domain isolation buffer umi_isolate over both of
+ *   its build-time arms, which are different circuits sharing a port
+ *   list (umi_isolate.v:50-89):
+ *
+ *   ISO=1  la_isolo cells on every wire. Two laws:
+ *            a_iso_clamp  isolate high drives the whole channel to
+ *                         zero, VALID and READY included, so a
+ *                         powered-down neighbour can neither offer nor
+ *                         accept a beat
+ *            a_iso_pass   isolate low passes every wire through
+ *                         unchanged
+ *   ISO=0  no cells at all -- a_iso_pass alone, unconditionally, and
+ *          a_iso_noclamp records what that means: with the cells
+ *          compiled out the isolate input is inert, so a build that
+ *          asks for isolation it did not compile in gets none. The row
+ *          exists so that arm is judged rather than assumed harmless.
+ *
+ * Purely combinational, so induction closes immediately; the value of
+ * prove mode is the quantifier over every input word.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   isolate:prove         ISO=1, both laws, unbounded
+ *   isolate:prove_iso0    ISO=0, passthrough, unbounded
+ *   isolate:cover         witnesses: expect all reached
+ *   isolate:fault_pass    must FAIL, a_iso_pass
+ *   isolate:fault_clamp   must FAIL, a_iso_clamp
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_isolate #(
+    parameter CW  = 32,
+    parameter AW  = 64,
+    parameter DW  = 64,
+    parameter ISO = 1
+) (
+    input wire clk
+);
+
+    localparam PW = CW + AW + AW + DW;
+
+    (* anyseq *) wire          isolate;
+    (* anyseq *) wire          umi_ready;
+    (* anyseq *) wire          umi_valid;
+    (* anyseq *) wire [CW-1:0] umi_cmd;
+    (* anyseq *) wire [AW-1:0] umi_dstaddr;
+    (* anyseq *) wire [AW-1:0] umi_srcaddr;
+    (* anyseq *) wire [DW-1:0] umi_data;
+
+    wire          umi_ready_iso;
+    wire          umi_valid_iso;
+    wire [CW-1:0] umi_cmd_iso;
+    wire [AW-1:0] umi_dstaddr_iso;
+    wire [AW-1:0] umi_srcaddr_iso;
+    wire [DW-1:0] umi_data_iso;
+
+    umi_isolate #(
+        .CW (CW), .AW (AW), .DW (DW), .ISO (ISO)
+    ) dut (
+        .isolate         (isolate),
+        .umi_ready       (umi_ready),
+        .umi_valid       (umi_valid),
+        .umi_cmd         (umi_cmd),
+        .umi_dstaddr     (umi_dstaddr),
+        .umi_srcaddr     (umi_srcaddr),
+        .umi_data        (umi_data),
+        .umi_ready_iso   (umi_ready_iso),
+        .umi_valid_iso   (umi_valid_iso),
+        .umi_cmd_iso     (umi_cmd_iso),
+        .umi_dstaddr_iso (umi_dstaddr_iso),
+        .umi_srcaddr_iso (umi_srcaddr_iso),
+        .umi_data_iso    (umi_data_iso)
+    );
+
+    // ----------------------------------------------------------------
+    // observed outputs: the faults corrupt what the laws see, never the
+    // DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_PASS
+    // a wire that does not survive the transparent path
+    wire [DW-1:0] obs_data = umi_data_iso ^ {DW{f_glitch}};
+`else
+    wire [DW-1:0] obs_data = umi_data_iso;
+`endif
+
+`ifdef FV_FAULT_CLAMP
+    // a wire that keeps driving through the clamp
+    wire obs_valid = umi_valid_iso | (isolate & f_glitch);
+`else
+    wire obs_valid = umi_valid_iso;
+`endif
+
+    wire [PW-1:0] in_bundle  = {umi_cmd, umi_dstaddr, umi_srcaddr, umi_data};
+    wire [PW-1:0] out_bundle = {umi_cmd_iso, umi_dstaddr_iso,
+                                umi_srcaddr_iso, obs_data};
+
+    // ----------------------------------------------------------------
+    // the two arms
+    // ----------------------------------------------------------------
+    generate
+        if (ISO == 1) begin : g_iso
+            always @(*) begin
+                if (isolate) begin
+                    a_iso_clamp : assert (!obs_valid && !umi_ready_iso
+                                          && (out_bundle == {PW{1'b0}}));
+                end else begin
+                    a_iso_pass : assert ((obs_valid == umi_valid)
+                                         && (umi_ready_iso == umi_ready)
+                                         && (out_bundle == in_bundle));
+                end
+            end
+        end else begin : g_noiso
+            always @(*) begin
+                // the cells are compiled out, so the channel is
+                // transparent whatever isolate is doing
+                a_iso_pass : assert ((obs_valid == umi_valid)
+                                     && (umi_ready_iso == umi_ready)
+                                     && (out_bundle == in_bundle));
+                // and isolate is inert: asking for isolation in a build
+                // that did not compile it in changes nothing
+                a_iso_noclamp : assert (!isolate || (obs_valid == umi_valid));
+            end
+        end
+    endgenerate
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(*) begin
+        // both sides of the clamp are really visited, and a live beat
+        // really does cross the transparent path
+        c_iso_clamped : cover (isolate);
+        c_iso_open    : cover (!isolate);
+        c_iso_beat    : cover (!isolate && umi_valid && umi_ready
+                               && (umi_data != {DW{1'b0}}));
+        // a non-zero payload standing at the clamp: the case that
+        // separates a_iso_clamp from a link that happened to be idle
+        c_iso_blocked : cover (isolate && umi_valid
+                               && (umi_data != {DW{1'b0}}));
+    end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_isolate.sv
+++ b/umi/formal/sumi/fv_umi_isolate.sv
@@ -28,11 +28,10 @@
  *                         accept a beat
  *            a_iso_pass   isolate low passes every wire through
  *                         unchanged
- *   ISO=0  no cells at all -- a_iso_pass alone, unconditionally, and
- *          a_iso_noclamp records what that means: with the cells
- *          compiled out the isolate input is inert, so a build that
- *          asks for isolation it did not compile in gets none. The row
- *          exists so that arm is judged rather than assumed harmless.
+ *   ISO=0  no cells at all -- a_iso_pass alone, unconditionally. That
+ *          is already the whole claim for this arm: the channel passes
+ *          through whatever isolate is doing, so a build that asks for
+ *          isolation it did not compile in gets none.
  *
  * Purely combinational, so induction closes immediately; the value of
  * prove mode is the quantifier over every input word.
@@ -138,9 +137,6 @@ module fv_umi_isolate #(
                 a_iso_pass : assert ((obs_valid == umi_valid)
                                      && (umi_ready_iso == umi_ready)
                                      && (out_bundle == in_bundle));
-                // and isolate is inert: asking for isolation in a build
-                // that did not compile it in changes nothing
-                a_iso_noclamp : assert (!isolate || (obs_valid == umi_valid));
             end
         end
     endgenerate

--- a/umi/formal/sumi/fv_umi_memif.sv
+++ b/umi/formal/sumi/fv_umi_memif.sv
@@ -18,8 +18,14 @@
  * Documentation:
  *
  * - Proves the read-modify-write unit in umi_memif computes each of the
- *   nine atomic operations README.md section 3.4.6 defines, and pins
- *   down what it does with an ATYPE that names none of them.
+ *   atomic operations it implements, and pins down what it does with an
+ *   ATYPE that names none of them.
+ *
+ *   README.md section 3.4.6 names eight: ADD, OR, XOR, MAX, MIN, MAXU,
+ *   MINU, SWAP. The RTL implements a ninth, ATOMICAND, which
+ *   umi_messages.vh:85 assigns ATYPE 0x01 and no section of the
+ *   specification lists. It is proven here because it is shipped, not
+ *   because the specification asks for it.
  *
  * THE OPERAND ALIGNMENT, AND WHY THE HARNESS REMOVES IT. umi_memif does
  * not feed the ALU the raw operands. It left-justifies both of them --
@@ -215,7 +221,7 @@ module fv_umi_memif #(
 `endif
 
     // ----------------------------------------------------------------
-    // the nine defined operations, and the arm that catches the rest
+    // the nine implemented operations, and the arm that catches the rest
     // ----------------------------------------------------------------
     always @(posedge clk)
         if (f_past_exists & nreset & past_nreset & atomic_active) begin

--- a/umi/formal/sumi/fv_umi_memif.sv
+++ b/umi/formal/sumi/fv_umi_memif.sv
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves the read-modify-write unit in umi_memif computes each of the
+ *   nine atomic operations README.md section 3.4.6 defines, and pins
+ *   down what it does with an ATYPE that names none of them.
+ *
+ * THE OPERAND ALIGNMENT, AND WHY THE HARNESS REMOVES IT. umi_memif does
+ * not feed the ALU the raw operands. It left-justifies both of them --
+ * umi_wrdata_r is the request data shifted up by DW minus the transfer
+ * width (umi_memif.v:115), and mem_rddata_atomic is the memory word
+ * masked and shifted the same way (umi_memif.v:122) -- runs the
+ * operation there, and shifts the result back down on the way out
+ * (umi_memif.v:156). The justification is what makes the signed
+ * comparisons work: it puts the operand's sign bit at bit DW-1 whatever
+ * the transfer width is.
+ *
+ * That shifting is not what these rows are about, and leaving it in
+ * would mean asserting the arithmetic through two shifts and a mask --
+ * which is the RTL's own expression written twice. So the harness
+ * assumes ONE transfer shape: a full-width, size-aligned atomic
+ * (m_alu_size, m_alu_len, m_alu_align). At that shape umi_bytes is
+ * exactly DW/8, so postatomic_shift is zero, the mask is all ones, and
+ * every shift in the path is the identity. What is left at mem_wrdata
+ * is the bare operation, and the assertions below state the arithmetic
+ * directly.
+ *
+ * WHAT IS OBSERVED, AND WHAT IS SHADOWED. The atomic cycle is
+ * port-visible: umi_ready is exactly ~umi_atomic_r (umi_memif.v:96), so
+ * no hierarchical reference into the DUT is needed to know when the
+ * result is being written. ATYPE and the request data are not visible a
+ * cycle later, so the harness keeps its own one-cycle copies of those
+ * two PORT INPUTS. Copying an input is not copying logic: the registers
+ * here hold what was presented at the port, and the proof is still
+ * against the block's own output.
+ *
+ * THE LAWS. With a and b the two operands -- a the request data, b the
+ * memory word -- one per encoding (umi_messages.vh:84-92):
+ *   a_alu_add   0x00  a + b        a_alu_smax  0x04  signed max
+ *   a_alu_and   0x01  a & b        a_alu_smin  0x05  signed min
+ *   a_alu_or    0x02  a | b        a_alu_umax  0x06  unsigned max
+ *   a_alu_xor   0x03  a ^ b        a_alu_umin  0x07  unsigned min
+ *   a_alu_swap  0x08  a
+ *
+ * AND THE TENTH. ATYPE is eight bits and only 0x00-0x08 name an
+ * operation, so the case has a default arm, and that arm returns the
+ * request data (umi_memif.v:139) -- the same thing SWAP returns.
+ * a_alu_default asserts exactly that: an atomic carrying an ATYPE
+ * outside the defined set overwrites memory rather than being rejected
+ * or ignored. c_alu_default witnesses it is reachable.
+ *
+ * This is the second half of something fv_umi_decode already showed
+ * from the other end: umi_decode raises cmd_atomic on a command whose
+ * five-bit opcode is not REQ_ATOMIC, because it compares four bits
+ * (see c_dec_alias_atomic there). A command that is not an atomic can
+ * therefore reach this ALU, and if its ATYPE field is above 0x08 the
+ * result is a write of the request data. Neither block is doing
+ * anything its own code does not say; the composition is what is worth
+ * having written down. No property here calls it a defect.
+ *
+ * Outside these laws: partial-width and unaligned atomics (the RTL's
+ * own header records partial writes as unsupported), the memory
+ * interface timing, and the read path.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   memif:prove           all ten laws, unbounded
+ *   memif:cover           witnesses: expect all reached
+ *   memif:fault_add       must FAIL, a_alu_add
+ *   memif:fault_smax      must FAIL, a_alu_smax
+ *   memif:fault_swap      must FAIL, a_alu_swap
+ *   memif:fault_default   must FAIL, a_alu_default
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_memif #(
+    parameter DW = 64,
+    parameter AW = 64
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    localparam SHIFTW = $clog2(DW/8);    // byte offset bits in the address
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus
+    // ----------------------------------------------------------------
+    (* anyseq *) wire          umi_read;
+    (* anyseq *) wire          umi_write;
+    (* anyseq *) wire          umi_atomic;
+    (* anyseq *) wire [2:0]    umi_size;
+    (* anyseq *) wire [7:0]    umi_len;
+    (* anyseq *) wire [7:0]    umi_atype;
+    (* anyseq *) wire [AW-1:0] umi_addr;
+    (* anyseq *) wire [DW-1:0] umi_wrdata;
+    (* anyseq *) wire [DW-1:0] mem_rddata;
+
+    // ONE transfer shape: full width, size aligned. See THE OPERAND
+    // ALIGNMENT above -- this is what makes every shift the identity so
+    // the arithmetic is readable at the port.
+    always @(*) begin
+        m_alu_size  : assume (umi_size == SHIFTW[2:0]);
+        m_alu_len   : assume (umi_len == 8'd0);
+        m_alu_align : assume (umi_addr[SHIFTW-1:0] == {SHIFTW{1'b0}});
+    end
+
+    wire          umi_ready;
+    wire [DW-1:0] umi_rddata;
+    wire          mem_ce;
+    wire          mem_we;
+    wire [AW-1:0] mem_addr;
+    wire [DW-1:0] mem_wrmask;
+    wire [DW-1:0] mem_wrdata;
+
+    umi_memif #(
+        .DW (DW), .AW (AW)
+    ) dut (
+        .clk        (clk),
+        .nreset     (nreset),
+        .umi_read   (umi_read),
+        .umi_write  (umi_write),
+        .umi_atomic (umi_atomic),
+        .umi_size   (umi_size),
+        .umi_len    (umi_len),
+        .umi_atype  (umi_atype),
+        .umi_addr   (umi_addr),
+        .umi_wrdata (umi_wrdata),
+        .umi_rddata (umi_rddata),
+        .umi_ready  (umi_ready),
+        .mem_ce     (mem_ce),
+        .mem_we     (mem_we),
+        .mem_addr   (mem_addr),
+        .mem_wrmask (mem_wrmask),
+        .mem_wrdata (mem_wrdata),
+        .mem_rddata (mem_rddata)
+    );
+
+    // ----------------------------------------------------------------
+    // the two operands, as the block sees them on the write cycle
+    //
+    // atomic_active is read off umi_ready, which the block drives as
+    // ~umi_atomic_r, so the cycle is port-visible. a and b are the
+    // request data held one cycle and the memory word presented now.
+    // ----------------------------------------------------------------
+    reg [DW-1:0] wrdata_q;
+    reg [7:0]    atype_q;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            wrdata_q <= {DW{1'b0}};
+            atype_q  <= 8'h0;
+        end else begin
+            wrdata_q <= umi_wrdata;
+            atype_q  <= umi_atype;
+        end
+
+    wire atomic_active = ~umi_ready;
+    wire [DW-1:0] a = wrdata_q;
+    wire [DW-1:0] b = mem_rddata;
+
+    // ----------------------------------------------------------------
+    // observed result: the faults corrupt what the laws see, never the
+    // DUT, and each one is confined to a single encoding so it can
+    // convict only its own law. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_ADD
+    wire [DW-1:0] obs = mem_wrdata
+                      ^ ((atype_q == 8'h00) ? {DW{f_glitch}} : {DW{1'b0}});
+`elsif FV_FAULT_SMAX
+    wire [DW-1:0] obs = mem_wrdata
+                      ^ ((atype_q == 8'h04) ? {DW{f_glitch}} : {DW{1'b0}});
+`elsif FV_FAULT_SWAP
+    wire [DW-1:0] obs = mem_wrdata
+                      ^ ((atype_q == 8'h08) ? {DW{f_glitch}} : {DW{1'b0}});
+`elsif FV_FAULT_DEFAULT
+    wire [DW-1:0] obs = mem_wrdata
+                      ^ ((atype_q > 8'h08) ? {DW{f_glitch}} : {DW{1'b0}});
+`else
+    wire [DW-1:0] obs = mem_wrdata;
+`endif
+
+    // ----------------------------------------------------------------
+    // the nine defined operations, and the arm that catches the rest
+    // ----------------------------------------------------------------
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset & atomic_active) begin
+            a_alu_add : assert ((atype_q != UMI_REQ_ATOMICADD)
+                                || (obs == (a + b)));
+            a_alu_and : assert ((atype_q != UMI_REQ_ATOMICAND)
+                                || (obs == (a & b)));
+            a_alu_or : assert ((atype_q != UMI_REQ_ATOMICOR)
+                               || (obs == (a | b)));
+            a_alu_xor : assert ((atype_q != UMI_REQ_ATOMICXOR)
+                                || (obs == (a ^ b)));
+            a_alu_smax : assert ((atype_q != UMI_REQ_ATOMICMAX)
+                                 || (obs == (($signed(a) > $signed(b))
+                                             ? a : b)));
+            a_alu_smin : assert ((atype_q != UMI_REQ_ATOMICMIN)
+                                 || (obs == (($signed(a) > $signed(b))
+                                             ? b : a)));
+            a_alu_umax : assert ((atype_q != UMI_REQ_ATOMICMAXU)
+                                 || (obs == ((a > b) ? a : b)));
+            a_alu_umin : assert ((atype_q != UMI_REQ_ATOMICMINU)
+                                 || (obs == ((a > b) ? b : a)));
+            a_alu_swap : assert ((atype_q != UMI_REQ_ATOMICSWAP)
+                                 || (obs == a));
+            // an ATYPE naming no operation writes the request data --
+            // the same result SWAP gives
+            a_alu_default : assert ((atype_q <= UMI_REQ_ATOMICSWAP)
+                                    || (obs == a));
+        end
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset & atomic_active) begin
+            c_alu_add     : cover (atype_q == UMI_REQ_ATOMICADD);
+            c_alu_swap    : cover (atype_q == UMI_REQ_ATOMICSWAP);
+            // the undefined arm is reachable, and this is the cover the
+            // composition note in the header rests on
+            c_alu_default : cover (atype_q > UMI_REQ_ATOMICSWAP);
+            // an add that actually carries out of the low half, so the
+            // law is not passing on trivial operands
+            c_alu_carry   : cover ((atype_q == UMI_REQ_ATOMICADD)
+                                   && (a[DW/2-1:0] != {(DW/2){1'b0}})
+                                   && (b[DW/2-1:0] != {(DW/2){1'b0}})
+                                   && (obs[DW-1] != a[DW-1]));
+            // signed and unsigned maximum disagreeing on the same pair:
+            // the case that separates a_alu_smax from a_alu_umax
+            c_alu_signed_distinct : cover ((atype_q == UMI_REQ_ATOMICMAX)
+                                           && (($signed(a) > $signed(b))
+                                               != (a > b)));
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_monitor.sv
+++ b/umi/formal/sumi/fv_umi_monitor.sv
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves the passive bus monitor umi_monitor reports a transfer on
+ *   exactly the cycles README.md section 4.2 rule 1 defines one, and
+ *   on no others:
+ *
+ *     a_mon_beat  beat is high if and only if VALID and READY are both
+ *                 high on that cycle
+ *
+ * SCOPE, stated plainly. Outside `SIMULATION the whole block is one
+ * combinational assign (umi_monitor.v:59), so this is a small law and
+ * the row is worth what a small law is worth: it holds the definition
+ * of a transfer to the one in the specification, and the fault row
+ * makes sure it is still being checked. Everything else the block does
+ * -- the stall timeout, the opcode trace -- lives under `SIMULATION and
+ * is not compiled into a formal build, so nothing here speaks to it.
+ *
+ * The block drives no bus signal: its only output is beat
+ * (umi_monitor.v:50). That is a property of the port list, settled at
+ * elaboration by the parametrized lint in tests/test_lint.py, and no
+ * assertion here restates it.
+ *
+ * ONE LAW, DELIBERATELY. A cumulative version -- the beats reported
+ * since reset equal the transfers that occurred -- was written and
+ * then removed: a_mon_beat pins the wire on every cycle, so the two
+ * counts are equal by construction and the second assertion could not
+ * fail unless the first already had. It would have added a label to
+ * the inventory and no evidence. The beat counter that remains feeds
+ * c_mon_run only, as a witness that the link really moved several
+ * beats, and nothing asserts on it.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   monitor:prove       a_mon_beat, unbounded
+ *   monitor:cover       witnesses: expect all reached
+ *   monitor:fault_or    must FAIL, a_mon_beat -- beat driven from
+ *                       VALID or READY instead of both
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_monitor #(
+    parameter CW = 32,
+    parameter AW = 64,
+    parameter DW = 64
+) (
+    input wire clk
+);
+
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    (* anyseq *) wire          valid;
+    (* anyseq *) wire          ready;
+    (* anyseq *) wire [CW-1:0] cmd;
+    (* anyseq *) wire [AW-1:0] dstaddr;
+    (* anyseq *) wire [AW-1:0] srcaddr;
+    (* anyseq *) wire [DW-1:0] data;
+
+    wire beat;
+
+    umi_monitor #(
+        .CW (CW), .AW (AW), .DW (DW)
+    ) dut (
+        .valid   (valid),
+        .ready   (ready),
+        .cmd     (cmd),
+        .dstaddr (dstaddr),
+        .srcaddr (srcaddr),
+        .data    (data),
+        .clk     (clk),
+        .nreset  (nreset),
+        .beat    (beat)
+    );
+
+    // ----------------------------------------------------------------
+    // observed output: the faults corrupt what the laws see, never the
+    // DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_OR
+    // the classic mis-reading of rule 1: either signal rather than both
+    wire obs_beat = valid | ready;
+`else
+    wire obs_beat = beat;
+`endif
+
+    // ----------------------------------------------------------------
+    // the transfer definition
+    // ----------------------------------------------------------------
+    always @(*) begin
+        a_mon_beat : assert (obs_beat == (valid & ready));
+    end
+
+    // counted for the witness below only -- nothing asserts on this
+    localparam KW = 6;                     // cycle counts, modulo 64
+
+    reg [KW-1:0] beats_seen;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            beats_seen <= {KW{1'b0}};
+        else if (obs_beat)
+            beats_seen <= beats_seen + {{(KW-1){1'b0}}, 1'b1};
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset) begin
+            c_mon_beat  : cover (obs_beat);
+            // the two cycles a_mon_beat separates: an offer with no
+            // taker, and a taker with no offer
+            c_mon_stall : cover (valid & ~ready & ~obs_beat);
+            c_mon_idle  : cover (~valid & ready & ~obs_beat);
+            // and a run of transfers, so a_mon_count is not passing on
+            // a link that moved at most one beat
+            c_mon_run   : cover (beats_seen == {{(KW-2){1'b0}}, 2'd3});
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_monitor.sv
+++ b/umi/formal/sumi/fv_umi_monitor.sv
@@ -99,7 +99,6 @@ module fv_umi_monitor #(
     // observed output: the faults corrupt what the laws see, never the
     // DUT. No RTL is copied or edited.
     // ----------------------------------------------------------------
-    (* anyseq *) wire f_glitch;
 
 `ifdef FV_FAULT_OR
     // the classic mis-reading of rule 1: either signal rather than both
@@ -136,7 +135,7 @@ module fv_umi_monitor #(
             // taker, and a taker with no offer
             c_mon_stall : cover (valid & ~ready & ~obs_beat);
             c_mon_idle  : cover (~valid & ready & ~obs_beat);
-            // and a run of transfers, so a_mon_count is not passing on
+            // and a run of transfers, so a_mon_beat is not passing on
             // a link that moved at most one beat
             c_mon_run   : cover (beats_seen == {{(KW-2){1'b0}}, 2'd3});
         end

--- a/umi/formal/sumi/fv_umi_pipeline.sv
+++ b/umi/formal/sumi/fv_umi_pipeline.sv
@@ -1,0 +1,328 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves the single-cycle register stage umi_pipeline keeps the SUMI
+ *   handshake (README.md section 4.2 rules 2 and 3) and delivers every
+ *   beat it accepts -- once, in order, unchanged.
+ *
+ * READY IS EXTERNAL. umi_pipeline has no umi_in_ready port: the block
+ * header states the ready must be broadcast externally. This harness
+ * ties the upstream ready to umi_out_ready, and every law below is a
+ * law of that usage. A fabric that broadcasts something else is
+ * outside this proof.
+ *
+ * HANDSHAKE. umi_handshake_checker twice: ASSUME=1 upstream so the
+ * driver is legal, ASSUME=0 downstream so the stage is judged. Both
+ * output laws close unbounded. umi_out_valid changes only on a cycle
+ * where umi_out_ready is high (umi_pipeline.v:53) and the payload
+ * registers take the same enable (umi_pipeline.v:58), so an offer that
+ * is not being accepted can neither withdraw nor move.
+ *
+ * PAYLOAD IDENTITY. The handshake rules say WHEN a beat moves, never
+ * WHICH beat: a stage that swapped DSTADDR and SRCADDR obeys every one
+ * of them. Two laws close that, both read off the ports:
+ *
+ *   a_pipe_occupancy  the beats accepted and not yet delivered are
+ *                     exactly what the stage advertises -- one while
+ *                     umi_out_valid is high, none while it is low.
+ *                     Nothing dropped, duplicated or invented.
+ *   a_pipe_beat       the beat now offered is the beat that entered
+ *                     carrying that beat number, whole: CMD, DSTADDR,
+ *                     SRCADDR and DATA compared as one vector. Order
+ *                     rides along, because the number IS the accept
+ *                     order -- a swapped pair delivers the wrong
+ *                     payload against it.
+ *
+ * The tracked beat number is (* anyconst *), held for the whole trace:
+ * the solver picks which beat is checked, so proving the tracked one
+ * proves every one, and no shadow queue is needed. Numbers are three
+ * bits and wrap, which is sound because the stage holds at most one
+ * beat -- a_pipe_occupancy is that bound -- and so retires a number
+ * long before it comes round again.
+ *
+ * ENGINE. Every register this stage owns is a port (umi_pipeline.v:41-45
+ * are output reg), so k-induction closes both laws from the ports alone.
+ * umi_buffer needs abc pdr for the same claim only because its skid
+ * register is not observable; there is no hidden state here.
+ *
+ * The packet registers are deliberately unreset (block header), and
+ * formal starts them free. umi_out_valid is reset low and every law
+ * above is conditioned on it, so the stale payload is never offered.
+ *
+ * Outside these laws: progress (nothing here says an accepted beat is
+ * ever delivered -- this file asserts no liveness property), and any
+ * fabric that broadcasts a different upstream ready.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   pipeline:prove         the handshake at both faces, unbounded
+ *   pipeline:cover         handshake witnesses: expect all reached
+ *   pipeline:identity      a_pipe_occupancy + a_pipe_beat, unbounded
+ *   pipeline:identity_cover  the tracked beat is really delivered and
+ *                          an offer really stands unaccepted, so
+ *                          neither law passes vacuously
+ *   pipeline:prove_mask_off  RULE_EN=0 over a free output channel: with
+ *                          the mask cleared no rule is reported. The
+ *                          fault_mask_* rows are the other half
+ *   pipeline:fault_valid   must FAIL, chk_out.RULE2_valid_hold
+ *   pipeline:fault_data    must FAIL, chk_out.RULE3_data_stable
+ *   pipeline:fault_swap    must FAIL, a_pipe_beat
+ *   pipeline:fault_ghost   must FAIL, a_pipe_occupancy
+ *   pipeline:fault_mask_r2 must FAIL, RULE2_valid_hold (mask bit 0 only)
+ *   pipeline:fault_mask_r3data  must FAIL, RULE3_data_stable (bit 4)
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_pipeline #(
+    parameter CW = 32,
+    parameter AW = 64,
+    parameter DW = 64,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+    localparam PW = CW + AW + AW + DW;   // packed SUMI packet
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus (constrained only by the rules, via env_in below)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire          in_valid;
+    (* anyseq *) wire [CW-1:0] in_cmd;
+    (* anyseq *) wire [AW-1:0] in_dstaddr;
+    (* anyseq *) wire [AW-1:0] in_srcaddr;
+    (* anyseq *) wire [DW-1:0] in_data;
+    (* anyseq *) wire          out_ready;
+
+    wire            out_valid;
+    wire [CW-1:0]   out_cmd;
+    wire [AW-1:0]   out_dstaddr;
+    wire [AW-1:0]   out_srcaddr;
+    wire [DW-1:0]   out_data;
+
+    // the block broadcasts one ready: see READY IS EXTERNAL above
+    wire in_ready = out_ready;
+
+    wire [PW-1:0] in_packet  = {in_cmd, in_dstaddr, in_srcaddr, in_data};
+    wire [PW-1:0] out_packet = {out_cmd, out_dstaddr, out_srcaddr, out_data};
+
+    umi_pipeline #(
+        .CW (CW), .AW (AW), .DW (DW)
+    ) dut (
+        .clk             (clk),
+        .nreset          (nreset),
+        .umi_in_valid    (in_valid),
+        .umi_in_cmd      (in_cmd),
+        .umi_in_dstaddr  (in_dstaddr),
+        .umi_in_srcaddr  (in_srcaddr),
+        .umi_in_data     (in_data),
+        .umi_out_valid   (out_valid),
+        .umi_out_cmd     (out_cmd),
+        .umi_out_dstaddr (out_dstaddr),
+        .umi_out_srcaddr (out_srcaddr),
+        .umi_out_data    (out_data),
+        .umi_out_ready   (out_ready)
+    );
+
+    // ----------------------------------------------------------------
+    // observed output channel: the faults corrupt what the checker and
+    // the identity laws see, never the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire            f_glitch;
+    (* anyseq *) wire            f_ghost;
+
+`ifdef FV_FAULT_FREEOUT
+    // the observed channel is entirely free: with the mask open every
+    // handshake rule is breakable, so a single enabled bit names the
+    // rule that gets reported
+    (* anyseq *) wire            obs_valid;
+    (* anyseq *) wire [CW-1:0]   obs_cmd;
+    (* anyseq *) wire [AW-1:0]   obs_dstaddr;
+    (* anyseq *) wire [AW-1:0]   obs_srcaddr;
+    (* anyseq *) wire [DW-1:0]   obs_data;
+`else
+ `ifdef FV_FAULT_VALID
+    // an offer withdrawn without being accepted: rule 2
+    wire obs_valid = out_valid & ~f_glitch;
+ `elsif FV_FAULT_GHOST
+    // a beat the stage never accepted, offered anyway. The offer is
+    // made a LEGAL one -- it rises out of reset and then changes only
+    // on a cycle the receiver accepts, exactly as umi_pipeline drives
+    // its own valid -- so every handshake rule still holds and the
+    // accounting law is the only thing that can report it.
+    reg ghost_q;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            ghost_q <= 1'b0;
+        else if (out_ready)
+            ghost_q <= f_ghost;
+    wire obs_valid = out_valid | ghost_q;
+ `else
+    wire obs_valid = out_valid;
+ `endif
+
+ `ifdef FV_FAULT_DATA
+    // payload moving underneath a standing offer: rule 3
+    wire [DW-1:0] obs_data = out_data ^ {DW{f_glitch}};
+ `else
+    wire [DW-1:0] obs_data = out_data;
+ `endif
+
+ `ifdef FV_FAULT_SWAP
+    // the two addresses exchanged: every handshake rule still holds --
+    // the swap is stable and the timing is untouched -- and only the
+    // identity law can see it
+    wire [AW-1:0] obs_dstaddr = out_srcaddr;
+    wire [AW-1:0] obs_srcaddr = out_dstaddr;
+ `else
+    wire [AW-1:0] obs_dstaddr = out_dstaddr;
+    wire [AW-1:0] obs_srcaddr = out_srcaddr;
+ `endif
+
+    wire [CW-1:0] obs_cmd = out_cmd;
+`endif
+
+    wire [PW-1:0] obs_packet = {obs_cmd, obs_dstaddr, obs_srcaddr, obs_data};
+
+    // ----------------------------------------------------------------
+    // the handshake, both faces of one rule list
+    // ----------------------------------------------------------------
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (1),                      // environment: assume legal input
+        .RULE_EN (RULE_EN)
+    ) env_in (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (in_valid),
+        .ready   (in_ready),
+        .cmd     (in_cmd),
+        .dstaddr (in_dstaddr),
+        .srcaddr (in_srcaddr),
+        .data    (in_data)
+    );
+
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (0),                      // requirement: assert legal output
+        .RULE_EN (RULE_EN)
+    ) chk_out (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (obs_valid),
+        .ready   (out_ready),
+        .cmd     (obs_cmd),
+        .dstaddr (obs_dstaddr),
+        .srcaddr (obs_srcaddr),
+        .data    (obs_data)
+    );
+
+    // ----------------------------------------------------------------
+    // payload identity (FV_IDENTITY rows only)
+    //
+    // Kept off the handshake rows on purpose: the accounting law reads
+    // the same obs_valid the handshake faults corrupt, and it breaks a
+    // cycle earlier than the rule those rows are aimed at, so leaving
+    // it live would let fault_valid convict a_pipe_occupancy and never
+    // exercise rule 2 at all.
+    // ----------------------------------------------------------------
+`ifdef FV_IDENTITY
+    wire insert = in_valid  & in_ready;    // accepted at the input
+    wire remove = obs_valid & out_ready;   // delivered at the output
+
+    localparam IW = 3;                     // beat numbers, modulo 8
+
+    reg [IW-1:0] in_cnt;
+    reg [IW-1:0] out_cnt;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            in_cnt  <= {IW{1'b0}};
+            out_cnt <= {IW{1'b0}};
+        end else begin
+            if (insert)
+                in_cnt  <= in_cnt  + {{(IW-1){1'b0}}, 1'b1};
+            if (remove)
+                out_cnt <= out_cnt + {{(IW-1){1'b0}}, 1'b1};
+        end
+
+    // ONE arbitrary beat number, constant for the whole trace. The
+    // solver picks it, so proving the tracked beat proves every beat.
+    (* anyconst *) wire [IW-1:0] fv_beat;
+    reg [PW-1:0] tracked;
+    always @(posedge clk)
+        if (insert && (in_cnt == fv_beat))
+            tracked <= in_packet;
+
+    // what the stage advertises it is holding: one beat while VALID is
+    // high, none while it is low
+    wire [IW-1:0] port_occ = {{(IW-1){1'b0}}, obs_valid};
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            a_pipe_occupancy : assert ((in_cnt - out_cnt) == port_occ);
+            if (obs_valid && (out_cnt == fv_beat))
+                a_pipe_beat : assert (obs_packet == tracked);
+        end
+
+    // witnesses: neither identity law is passing on an idle link
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            // the tracked beat really is delivered
+            c_pipe_deliver : cover (remove && (out_cnt == fv_beat));
+            // an offer really does stand unaccepted -- the case
+            // a_pipe_beat covers that a delivery alone would not reach
+            c_pipe_stall   : cover (obs_valid && !out_ready);
+            // and the stage really does run full rate, accepting and
+            // delivering on the same cycle
+            c_pipe_fullrate : cover (insert && remove);
+        end
+`endif
+
+    // ----------------------------------------------------------------
+    // handshake witnesses: live on every row, so no handshake proof
+    // passes over a link that never moves a beat or never stalls
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_pipe_xfer  : cover (obs_valid & out_ready);
+            c_pipe_wait  : cover (obs_valid & ~out_ready);
+            c_pipe_empty : cover (~obs_valid);
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_pipeline.sv
+++ b/umi/formal/sumi/fv_umi_pipeline.sv
@@ -136,7 +136,6 @@ module fv_umi_pipeline #(
     wire in_ready = out_ready;
 
     wire [PW-1:0] in_packet  = {in_cmd, in_dstaddr, in_srcaddr, in_data};
-    wire [PW-1:0] out_packet = {out_cmd, out_dstaddr, out_srcaddr, out_data};
 
     umi_pipeline #(
         .CW (CW), .AW (AW), .DW (DW)

--- a/umi/formal/sumi/fv_umi_ram.sv
+++ b/umi/formal/sumi/fv_umi_ram.sv
@@ -1,0 +1,324 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves umi_ram returns each answer to the port that asked for it,
+ *   and shows what happens when the field it routes on is not what the
+ *   convention assumes.
+ *
+ * THE ROUTING IS A FIELD IN THE ADDRESS, NOT A TAG. umi_ram broadcasts
+ * one answer to every port and gates each port's VALID with one bit of
+ * the response address (umi_ram.v:106-108):
+ *
+ *   udev_resp_valid[N-1:0] = mem_resp_dstaddr[IDOFF+:N] & {N{mem_resp_valid}};
+ *   mem_resp_ready         = |(mem_resp_dstaddr[IDOFF+:N] & udev_resp_ready)
+ *                          | ~mem_resp_valid;
+ *
+ * That field arrives from the requester: umi_endpoint sets the response
+ * DSTADDR to the request SRCADDR, so whatever a port puts in
+ * SRCADDR[IDOFF+:N] is what steers its answer home. Nothing in the
+ * block checks it, and the two ways it can be wrong are different
+ * failures:
+ *
+ *   more than one bit set   the same answer is delivered to several
+ *                           ports at once
+ *   no bit set              every udev_resp_valid is low, so
+ *                           mem_resp_ready is low while mem_resp_valid
+ *                           is high. The answer can never retire, the
+ *                           memory never accepts another request, and
+ *                           the block is wedged for good
+ *
+ * WHAT IS PROVEN. With the convention held -- port i sets exactly its
+ * own bit, m_ram_id -- one law closes:
+ *
+ *   a_ram_route     a port is only offered an answer that carries its
+ *                   own id bit
+ *
+ * WHAT IS NOT, AND IS PINNED INSTEAD. Two claims a reader would expect
+ * beside it do not hold, and each has a row that requires the failure
+ * so it cannot regress into silence:
+ *
+ *   rule 3 on the response ports. The response address is broadcast to
+ *   every port, and it MOVES while an answer is standing unaccepted:
+ *   ram:fault_stable puts the handshake checker back on and requires
+ *   RULE3_dstaddr_stable to fail. Nothing is injected on that row. The
+ *   counterexample needs one accepted request and then changes the
+ *   broadcast address underneath it. The green rows therefore run with
+ *   the response checker lifted (FV_RAM_NOCHK), which is stated here
+ *   rather than left for a reader to notice.
+ *
+ *   one answer to one port. c_ram_dup_conv reaches two ports being
+ *   offered the same answer at once WITH m_ram_id still held, so the
+ *   duplicate delivery is not something only a misbehaving requester
+ *   can cause.
+ *
+ * WHAT IS WITNESSED. ram:hazard drops m_ram_id and covers both failures
+ * the convention is holding off -- c_ram_dup for duplicate delivery,
+ * c_ram_wedge for the lock-up. The wedge cover is the one to look at:
+ * it reaches a state where a request has been accepted, no port is
+ * being offered an answer, and the request side has been shut for
+ * several cycles. Same shape as the SAFE=1 row in fv_umi_regif.
+ *
+ * BOUNDED. umi_ram is a composite: umi_mux in front, umi_memagent
+ * behind it, and inside that a umi_endpoint, a umi_fifoflex and a real
+ * la_spram. The memory array and the arbiter thermometer are both
+ * unobservable from these ports, so induction starts from states no
+ * trace reaches. These rows are bmc and are labelled bounded.
+ *
+ * SIZE. N=2, DW=64, AW=64, RAMDEPTH=8. IDOFF stays at its default of
+ * 40, which requires AW above 41, so the address stays wide while the
+ * memory is made small -- the routing law does not depend on how many
+ * words sit behind it.
+ *
+ * Outside these laws: what the memory returns (that is fv_umi_memif for
+ * the arithmetic and fv_umi_endpoint for the request/response glue),
+ * arbitration fairness between the ports, and progress.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   ram:bmc           a_ram_route, bounded, response checker lifted
+ *   ram:cover         witnesses: expect all reached, including
+ *                     c_ram_dup_conv
+ *   ram:hazard        m_ram_id dropped; c_ram_dup and c_ram_wedge reach
+ *                     the two failures the convention holds off
+ *   ram:fault_route   must FAIL, a_ram_route
+ *   ram:fault_stable  the response checker put back, nothing injected:
+ *                     must FAIL, RULE3_dstaddr_stable
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_ram #(
+    parameter N        = 2,
+    parameter CW       = 32,
+    parameter AW       = 64,
+    parameter DW       = 64,
+    parameter IDOFF    = 40,
+    parameter RAMDEPTH = 8,
+    parameter CTRLW    = 8,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus, one bundle per port
+    // ----------------------------------------------------------------
+    (* anyseq *) wire [N-1:0]      req_valid;
+    (* anyseq *) wire [N*CW-1:0]   req_cmd;
+    (* anyseq *) wire [N*AW-1:0]   req_dstaddr;
+    (* anyseq *) wire [N*AW-1:0]   req_srcaddr;
+    (* anyseq *) wire [N*DW-1:0]   req_data;
+    (* anyseq *) wire [N-1:0]      resp_ready;
+    (* anyseq *) wire [CTRLW-1:0]  sram_ctrl;
+
+    wire [N-1:0]    req_ready;
+    wire [N-1:0]    resp_valid;
+    wire [N*CW-1:0] resp_cmd;
+    wire [N*AW-1:0] resp_dstaddr;
+    wire [N*AW-1:0] resp_srcaddr;
+    wire [N*DW-1:0] resp_data;
+
+    // the routing convention: port i steers its answer home by setting
+    // its own bit, and only its own bit, in the request SRCADDR. The
+    // block never checks this -- see the header.
+    // Per-port wires built in a loop, then one property over the
+    // vector: a procedural assertion label inside a generate loop is
+    // not uniquified by the elaborator, so the second iteration
+    // collides with the first. Same shape fv_umi_crossbar uses.
+    wire [N-1:0] id_ok;
+    wire [N-1:0] single;
+    genvar gi;
+    generate
+        for (gi = 0; gi < N; gi = gi + 1) begin : g_ram_id
+            assign id_ok[gi] = (req_srcaddr[gi*AW+IDOFF +: N]
+                                == (({{(N-1){1'b0}}, 1'b1}) << gi));
+            assign single[gi] = (req_cmd[gi*CW+UMI_LEN_LSB +: 8] == 8'd0);
+        end
+    endgenerate
+
+`ifndef FV_RAM_ANYID
+    always @(*)
+        m_ram_id : assume (&id_ok);
+`endif
+
+    // one beat per request while the split path is under investigation
+    always @(*)
+        m_ram_single : assume (&single);
+
+    umi_ram #(
+        .N (N), .DW (DW), .AW (AW), .CW (CW),
+        .IDOFF (IDOFF), .RAMDEPTH (RAMDEPTH), .CTRLW (CTRLW)
+    ) dut (
+        .clk               (clk),
+        .nreset            (nreset),
+        .sram_ctrl         (sram_ctrl),
+        .mode              (2'b10),          // round robin, per umi_arbiter.v:63
+        .udev_req_valid    (req_valid),
+        .udev_req_cmd      (req_cmd),
+        .udev_req_dstaddr  (req_dstaddr),
+        .udev_req_srcaddr  (req_srcaddr),
+        .udev_req_data     (req_data),
+        .udev_req_ready    (req_ready),
+        .udev_resp_valid   (resp_valid),
+        .udev_resp_cmd     (resp_cmd),
+        .udev_resp_dstaddr (resp_dstaddr),
+        .udev_resp_srcaddr (resp_srcaddr),
+        .udev_resp_data    (resp_data),
+        .udev_resp_ready   (resp_ready)
+    );
+
+    // ----------------------------------------------------------------
+    // observed response valids: the fault corrupts what the laws see,
+    // never the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_ROUTE
+    // an answer offered to a port whose id bit is clear
+    wire [N-1:0] obs_valid = resp_valid | {N{f_glitch}};
+`else
+    wire [N-1:0] obs_valid = resp_valid;
+`endif
+
+    // ----------------------------------------------------------------
+    // the handshake on every port, both faces of one rule list
+    // ----------------------------------------------------------------
+    wire [N-1:0] route_bad;
+    genvar i;
+    generate
+        for (i = 0; i < N; i = i + 1) begin : g_port
+            umi_handshake_checker #(
+                .CW (CW), .AW (AW), .DW (DW),
+                .ASSUME (1),              // environment: legal requests in
+                .RULE_EN (RULE_EN)
+            ) env_req (
+                .clk     (clk),
+                .nreset  (nreset),
+                .valid   (req_valid[i]),
+                .ready   (req_ready[i]),
+                .cmd     (req_cmd[i*CW +: CW]),
+                .dstaddr (req_dstaddr[i*AW +: AW]),
+                .srcaddr (req_srcaddr[i*AW +: AW]),
+                .data    (req_data[i*DW +: DW])
+            );
+
+`ifndef FV_RAM_NOCHK
+            umi_handshake_checker #(
+                .CW (CW), .AW (AW), .DW (DW),
+                .ASSUME (0),              // requirement: legal answers out
+                .RULE_EN (RULE_EN)
+            ) chk_resp (
+                .clk     (clk),
+                .nreset  (nreset),
+                .valid   (obs_valid[i]),
+                .ready   (resp_ready[i]),
+                .cmd     (resp_cmd[i*CW +: CW]),
+                .dstaddr (resp_dstaddr[i*AW +: AW]),
+                .srcaddr (resp_srcaddr[i*AW +: AW]),
+                .data    (resp_data[i*DW +: DW])
+            );
+
+`endif
+            // a port offered an answer that does not carry its own id
+            // bit. The address is broadcast, so this reads the same
+            // field the block gates on -- off a port.
+            assign route_bad[i] = obs_valid[i]
+                                & ~resp_dstaddr[i*AW+IDOFF+i];
+        end
+    endgenerate
+
+    // ----------------------------------------------------------------
+    // at most one port offered an answer at a time
+    // ----------------------------------------------------------------
+`ifndef FV_RAM_ANYID
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset)
+            a_ram_route : assert (route_bad == {N{1'b0}});
+`endif
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    wire any_req_beat = |(req_valid & req_ready);
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_ram_req0  : cover (req_valid[0] & req_ready[0]);
+            c_ram_req1  : cover (req_valid[1] & req_ready[1]);
+            c_ram_resp0 : cover (obs_valid[0] & resp_ready[0]);
+            c_ram_resp1 : cover (obs_valid[1] & resp_ready[1]);
+            c_ram_wait  : cover (|obs_valid & ~|resp_ready);
+            c_ram_bp    : cover (~|req_ready);
+            // one answer offered to BOTH ports at once, reached with
+            // the request-side convention still held -- see the header
+            c_ram_dup_conv : cover (&obs_valid);
+        end
+
+ `ifdef FV_RAM_ANYID
+    // the two failures the routing convention is holding off. Both are
+    // behaviour of the shipped block, not faults this harness injects.
+    reg accepted;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            accepted <= 1'b0;
+        else if (any_req_beat)
+            accepted <= 1'b1;
+
+    // how long the request side has been refusing everything
+    reg [3:0] blocked;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            blocked <= 4'd0;
+        else if (|req_ready)
+            blocked <= 4'd0;
+        else if (blocked != 4'hF)
+            blocked <= blocked + 4'd1;
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            // one answer handed to both ports at once
+            c_ram_dup   : cover (&resp_valid);
+            // a request was taken, nobody is being offered an answer,
+            // and the request side has been shut for several cycles
+            c_ram_wedge : cover (accepted & ~|resp_valid & (blocked >= 4'd3));
+        end
+ `endif
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_regif.sv
+++ b/umi/formal/sumi/fv_umi_regif.sv
@@ -1,0 +1,358 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves umi_regif answers a register request with the right kind of
+ *   response and keeps the SUMI handshake on the response channel --
+ *   and shows where that second claim stops holding.
+ *
+ * THE TWO ARMS ARE DIFFERENT CIRCUITS. umi_regif builds its request
+ * ready two ways (umi_regif.v:117-121):
+ *
+ *   SAFE=0   udev_req_ready = reg_ready & (udev_resp_ready | ~udev_resp_valid)
+ *   SAFE=1   udev_req_ready = reg_ready & udev_req_safe_ready
+ *
+ * The SAFE=0 form refuses a new request unless the response channel is
+ * free or is being drained this cycle, so a response is never replaced
+ * before it is taken. That arm is proven here: the response channel
+ * satisfies README.md section 4.2 rules 2 and 3.
+ *
+ * The SAFE=1 form deliberately breaks the combinational path from
+ * udev_resp_ready back to udev_req_ready -- the block header explains
+ * why, it is there to keep integrators out of combinational loops --
+ * and replaces it with a one-cycle stall register
+ * (umi_regif.v:107-113). That register does not know whether the
+ * previous response was accepted. So a second request can be taken
+ * while the first response is still standing, and the response payload
+ * is then overwritten under an offer nobody has accepted.
+ *
+ * This harness does not assert that away and does not paper over it.
+ * The SAFE=0 arm carries the handshake proof. SAFE=1 gets two rows: a
+ * hazard row that reaches the overwrite and produces the trace
+ * (c_regif_overwrite), and a fault row that leaves the accounting law
+ * in and requires it to FAIL on a_regif_outstanding. The second is
+ * there so the finding cannot quietly go away: if a later change makes
+ * SAFE=1 hold the law, that row goes green and the lane reports it.
+ *
+ * SAFE defaults to 1 (umi_regif.v:43), so the hazard row is the
+ * configuration an integrator gets without asking.
+ *
+ * WHAT IS PROVEN, both arms unless noted:
+ *   RULE2_valid_hold / RULE3_*_stable   the response channel
+ *                     (SAFE=0 only -- see above)
+ *   a_regif_kind      a read is answered RESP_READ and a write
+ *                     RESP_WRITE, per README 3.4.11 and 3.4.12
+ *   a_regif_outstanding  the block holds at most one answer, and holds
+ *                     one exactly while VALID is high. This is the
+ *                     accounting law, and the one SAFE=1 breaks
+ *   a_regif_no_invent a posted write raises no response at all
+ *                     (README 3.4.4)
+ *
+ * The register-side outputs (reg_write, reg_read, reg_addr, reg_wdata)
+ * are single assigns off the request word, and asserting each against
+ * its own expression would be the code read back, so they are not
+ * asserted. What is asserted is the part that is not a restatement:
+ * a_regif_no_invent, which says a posted write leaves the response side
+ * quiet, and a_regif_outstanding, an accounting law over time.
+ *
+ * Outside these laws: the register file behind the interface, error
+ * propagation from reg_err, and the group-address decode.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   regif:prove            SAFE=0, all laws, unbounded
+ *   regif:cover            witnesses: expect all reached
+ *   regif:hazard           SAFE=1, response checker and the accounting
+ *                          law both lifted; the overwrite is witnessed
+ *                          by c_regif_overwrite
+ *   regif:fault_safe       SAFE=1 with the accounting law LEFT IN --
+ *                          must FAIL on a_regif_outstanding. The
+ *                          shipped default configuration is the fault
+ *                          here; nothing is injected. This row is what
+ *                          stops the finding regressing silently
+ *   regif:fault_valid      must FAIL, chk_resp.RULE2_valid_hold
+ *   regif:fault_kind       must FAIL, a_regif_kind_wr (the xor
+ *                          swaps the two response opcodes, so either
+ *                          half of the kind law can catch it)
+ *   regif:fault_posted     must FAIL, a_regif_no_invent
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_regif #(
+    parameter RW   = 32,
+    parameter RAW  = 32,
+    parameter SAFE = 0,
+    parameter CW   = 32,
+    parameter AW   = 64,
+    parameter DW   = 64,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+`include "umi_messages.vh"
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus
+    // ----------------------------------------------------------------
+    (* anyseq *) wire          req_valid;
+    (* anyseq *) wire [CW-1:0] req_cmd;
+    (* anyseq *) wire [AW-1:0] req_dstaddr;
+    (* anyseq *) wire [AW-1:0] req_srcaddr;
+    (* anyseq *) wire [DW-1:0] req_data;
+    (* anyseq *) wire          resp_ready;
+    (* anyseq *) wire [RW-1:0] reg_rdata;
+    (* anyseq *) wire [1:0]    reg_err;
+    (* anyseq *) wire          reg_ready;
+
+    wire          req_ready;
+    wire          resp_valid;
+    wire [CW-1:0] resp_cmd;
+    wire [AW-1:0] resp_dstaddr;
+    wire [AW-1:0] resp_srcaddr;
+    wire [DW-1:0] resp_data;
+    wire          reg_write;
+    wire          reg_read;
+    wire [RAW-1:0] reg_addr;
+    wire [RW-1:0] reg_wdata;
+    wire [1:0]    reg_prot;
+
+    umi_regif #(
+        .RW (RW), .RAW (RAW), .SAFE (SAFE),
+        .CW (CW), .AW (AW), .DW (DW)
+    ) dut (
+        .clk             (clk),
+        .nreset          (nreset),
+        .udev_req_valid  (req_valid),
+        .udev_req_cmd    (req_cmd),
+        .udev_req_dstaddr(req_dstaddr),
+        .udev_req_srcaddr(req_srcaddr),
+        .udev_req_data   (req_data),
+        .udev_req_ready  (req_ready),
+        .udev_resp_valid (resp_valid),
+        .udev_resp_cmd   (resp_cmd),
+        .udev_resp_dstaddr(resp_dstaddr),
+        .udev_resp_srcaddr(resp_srcaddr),
+        .udev_resp_data  (resp_data),
+        .udev_resp_ready (resp_ready),
+        .reg_write       (reg_write),
+        .reg_read        (reg_read),
+        .reg_addr        (reg_addr),
+        .reg_wdata       (reg_wdata),
+        .reg_prot        (reg_prot),
+        .reg_rdata       (reg_rdata),
+        .reg_err         (reg_err),
+        .reg_ready       (reg_ready)
+    );
+
+    // ----------------------------------------------------------------
+    // the request the device is answering
+    // ----------------------------------------------------------------
+    wire beat        = req_valid & req_ready;
+    wire cmd_read    = (req_cmd[4:0] == UMI_REQ_READ);
+    wire cmd_write   = (req_cmd[4:0] == UMI_REQ_WRITE);
+    wire cmd_posted  = (req_cmd[4:0] == UMI_REQ_POSTED);
+    wire responds    = cmd_read | cmd_write;
+
+    // ----------------------------------------------------------------
+    // observed response: the faults corrupt what the laws see, never
+    // the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_VALID
+    wire obs_valid = resp_valid & ~f_glitch;
+`elsif FV_FAULT_POSTED
+    // a posted write answered anyway
+    reg posted_q;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            posted_q <= 1'b0;
+        else
+            posted_q <= beat & cmd_posted & f_glitch;
+    wire obs_valid = resp_valid | posted_q;
+`else
+    wire obs_valid = resp_valid;
+`endif
+
+`ifdef FV_FAULT_KIND
+    // The two response opcodes exchanged: RESP_READ 0x02 and RESP_WRITE
+    // 0x04 differ by 0x06, so one constant xor swaps them. Constant on
+    // purpose -- a per-cycle flip would move the payload under a
+    // standing offer and convict rule 3 before ever reaching the law
+    // this row is aimed at.
+    wire [CW-1:0] obs_cmd = resp_cmd ^ {{(CW-5){1'b0}}, 5'b00110};
+`else
+    wire [CW-1:0] obs_cmd = resp_cmd;
+`endif
+
+    // ----------------------------------------------------------------
+    // the two channels
+    // ----------------------------------------------------------------
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (1),                      // environment: assume legal input
+        .RULE_EN (RULE_EN)
+    ) env_req (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (req_valid),
+        .ready   (req_ready),
+        .cmd     (req_cmd),
+        .dstaddr (req_dstaddr),
+        .srcaddr (req_srcaddr),
+        .data    (req_data)
+    );
+
+`ifndef FV_REGIF_NOCHK
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (0),                      // requirement: assert legal output
+        .RULE_EN (RULE_EN)
+    ) chk_resp (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (obs_valid),
+        .ready   (resp_ready),
+        .cmd     (obs_cmd),
+        .dstaddr (resp_dstaddr),
+        .srcaddr (resp_srcaddr),
+        .data    (resp_data)
+    );
+`endif
+
+    // ----------------------------------------------------------------
+    // answering the right question
+    // ----------------------------------------------------------------
+    reg was_read;
+    reg was_write;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            was_read  <= 1'b0;
+            was_write <= 1'b0;
+        end else if (beat & responds) begin
+            was_read  <= cmd_read;
+            was_write <= cmd_write;
+        end
+
+    // accounting: an answer for every question, never one more
+    localparam KW = 5;
+    reg [KW-1:0] asked;
+    reg [KW-1:0] answered;
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            asked    <= {KW{1'b0}};
+            answered <= {KW{1'b0}};
+        end else begin
+            if (beat & responds)
+                asked <= asked + {{(KW-1){1'b0}}, 1'b1};
+            if (resp_valid & resp_ready)
+                answered <= answered + {{(KW-1){1'b0}}, 1'b1};
+        end
+
+    // Outstanding answers, and the law that makes the accounting
+    // inductive. "answered never exceeds asked" is true but NOT
+    // inductive -- the counters wrap, so the step case may start from
+    // answered ahead of asked and the induction fails while the base
+    // case passes. The exact form below closes: the block holds at most
+    // one answer, and it is holding one exactly while VALID is high.
+    // In SAFE=1 this is also the law the overwrite breaks -- a second
+    // request is taken while the first answer still stands, so the
+    // count goes to two while VALID says one.
+    wire [KW-1:0] outstanding = asked - answered;
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            // a read is answered RESP_READ, a write RESP_WRITE
+            if (obs_valid & was_read)
+                a_regif_kind : assert (obs_cmd[4:0] == UMI_RESP_READ);
+            if (obs_valid & was_write & !was_read)
+                a_regif_kind_wr : assert (obs_cmd[4:0] == UMI_RESP_WRITE);
+`ifndef FV_REGIF_HAZARD
+            a_regif_outstanding : assert (outstanding
+                                          == {{(KW-1){1'b0}}, resp_valid});
+`endif
+        end
+
+    // the posted-write law, stated where it can be seen: after a beat
+    // that carried a posted write and nothing else is outstanding, the
+    // response channel must stay quiet
+    reg posted_only;
+    always @(posedge clk or negedge nreset)
+        if (!nreset)
+            posted_only <= 1'b0;
+        else
+            posted_only <= beat & cmd_posted & ~resp_valid;
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset & posted_only)
+            a_regif_no_invent : assert (~obs_valid);
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_regif_read   : cover (obs_valid & was_read);
+            c_regif_write  : cover (obs_valid & was_write & !was_read);
+            c_regif_xfer   : cover (obs_valid & resp_ready);
+            c_regif_wait   : cover (obs_valid & ~resp_ready);
+            c_regif_posted : cover (beat & cmd_posted);
+            c_regif_bp     : cover (~req_ready);
+        end
+
+ `ifdef FV_REGIF_HAZARD
+    // SAFE=1 only: the response payload replaced while the previous
+    // answer is still standing unaccepted. Reaching this is the whole
+    // point of the row -- it is the trace an integrator needs.
+    reg        rv_q;
+    reg        rr_q;
+    reg [AW-1:0] rsa_q;
+    always @(posedge clk) begin
+        rv_q  <= resp_valid;
+        rr_q  <= resp_ready;
+        rsa_q <= resp_srcaddr;
+    end
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset)
+            c_regif_overwrite : cover (rv_q & ~rr_q & resp_valid
+                                       & (resp_srcaddr != rsa_q));
+ `endif
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_stream.sv
+++ b/umi/formal/sumi/fv_umi_stream.sv
@@ -250,7 +250,6 @@ module fv_umi_stream #(
     // which carries DATA and LAST rather than a UMI packet
     // ----------------------------------------------------------------
     reg        usi_in_valid_q;
-    reg        usi_in_last_q;
     reg [DW:0] usi_in_bundle_q;
     reg        usi_in_ready_q;
     always @(posedge clk) begin

--- a/umi/formal/sumi/fv_umi_stream.sv
+++ b/umi/formal/sumi/fv_umi_stream.sv
@@ -1,0 +1,310 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves the UMI-to-streaming bridge umi_stream keeps a legal
+ *   handshake on all four of its faces at once: the two UMI faces
+ *   against README.md section 4.2, and the two USI faces against the
+ *   same two rules written out directly, since a USI beat carries
+ *   DATA and LAST rather than a UMI packet and umi_handshake_checker
+ *   does not fit it.
+ *
+ * ONE CLOCK. THIS IS THE SCOPE. umi_stream spans two domains --
+ * umi_clk and usi_clk -- through two la_asyncfifo instances (S2MM and
+ * MM2S). This harness ties the two clocks and the two resets and
+ * proves the block in that configuration. It catches everything that
+ * does not depend on the clock ratio: the handshake logic, the
+ * pushback paths, the devicemode multiplexing. It says nothing about
+ * true asynchrony, because metastability is not in the Verilog
+ * semantics and the delay model that would make a synchroniser
+ * meaningful does not exist in this directory yet. The async behaviour
+ * is unverified here, not verified.
+ *
+ * BOUNDED, NOT UNBOUNDED. Bmc rows, for the reason fv_umi_fifo gives:
+ * the FIFO pointers cross la_drsync registers no port shows, so
+ * induction starts its step case from pointer states no trace reaches.
+ *
+ * WHAT IS PROVEN.
+ *   RULE2_valid_hold / RULE3_*_stable   the UMI output face, with the
+ *                     UMI input face constrained legal by the same
+ *                     checker in its ASSUME face
+ *   a_usi_out_hold    a USI offer is not withdrawn before it is
+ *                     accepted
+ *   a_usi_out_stable  DATA and LAST do not move under a standing USI
+ *                     offer
+ * The USI input face is assumed to obey the same two rules, which is
+ * what any stream source is required to do.
+ *
+ * THE CONFIGURATION INPUTS MUST BE HELD. devicemode and the three
+ * s2mm_* inputs are (* anyconst *) here -- the solver picks any value
+ * but cannot move it mid-trace. That is not a convenience: in link
+ * mode the UMI output payload is a combinational function of s2mm_cmd
+ * and s2mm_dstaddr (umi_stream.v:227-228), so a controller that
+ * rewrites them while umi_out_valid is standing changes the payload
+ * under an unaccepted offer and breaks rule 3. Left free, this harness
+ * reports exactly that, which is how the condition was found. Both
+ * devicemode arms are still explored, one per trace, and c_str_device
+ * and c_str_link witness that both are reached.
+ *
+ * WHAT IS NOT PROVEN, and no row here should be read as claiming it:
+ * that a UMI packet arriving on the memory-mapped face comes out as
+ * the right stream beats, or the reverse. That is a payload-carriage
+ * claim across a width and framing change, it needs the byte
+ * accounting umi_fifoflex also wants, and it is not attempted here.
+ * This file is a handshake result and is labelled one.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   stream:bmc              all four faces, bounded
+ *   stream:cover            witnesses: expect all reached
+ *   stream:fault_valid      must FAIL, chk_umi_out.RULE2_valid_hold
+ *   stream:fault_data       must FAIL, chk_umi_out.RULE3_data_stable
+ *   stream:fault_usi_hold   must FAIL, a_usi_out_hold
+ *   stream:fault_usi_stable must FAIL, a_usi_out_stable
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_stream #(
+    parameter CW = 32,
+    parameter AW = 64,
+    parameter DW = 64,
+    parameter S2MM_DEPTH = 2,
+    parameter MM2S_DEPTH = 2,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus
+    // ----------------------------------------------------------------
+    // Configuration, not per-beat signals: held constant for the whole
+    // trace. This is load-bearing and it is a statement about how the
+    // block must be integrated, not a convenience. In link mode the UMI
+    // output payload is driven combinationally from these inputs
+    // (umi_stream.v:227-228, umi_out_cmd = devicemode ? resp_cmd_r :
+    // s2mm_cmd), so a controller that moves s2mm_cmd, s2mm_dstaddr,
+    // s2mm_srcaddr or devicemode while umi_out_valid is standing breaks
+    // rule 3 at the output -- the payload changes under an offer that
+    // has not been accepted. Left free, the harness reports exactly
+    // that. Whoever drives these must hold them.
+    (* anyconst *) wire          devicemode;
+    (* anyconst *) wire [AW-1:0] s2mm_dstaddr;
+    (* anyconst *) wire [AW-1:0] s2mm_srcaddr;
+    (* anyconst *) wire [CW-1:0] s2mm_cmd;
+
+    (* anyseq *) wire          umi_in_valid;
+    (* anyseq *) wire [CW-1:0] umi_in_cmd;
+    (* anyseq *) wire [AW-1:0] umi_in_dstaddr;
+    (* anyseq *) wire [AW-1:0] umi_in_srcaddr;
+    (* anyseq *) wire [DW-1:0] umi_in_data;
+    (* anyseq *) wire          umi_out_ready;
+
+    (* anyseq *) wire          usi_in_valid;
+    (* anyseq *) wire          usi_in_last;
+    (* anyseq *) wire [DW-1:0] usi_in_data;
+    (* anyseq *) wire          usi_out_ready;
+
+    wire          umi_in_ready;
+    wire          umi_out_valid;
+    wire [CW-1:0] umi_out_cmd;
+    wire [AW-1:0] umi_out_dstaddr;
+    wire [AW-1:0] umi_out_srcaddr;
+    wire [DW-1:0] umi_out_data;
+    wire          usi_out_valid;
+    wire          usi_out_last;
+    wire [DW-1:0] usi_out_data;
+    wire          usi_in_ready;
+
+    // both domains driven from the one clock and reset: see ONE CLOCK
+    umi_stream #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .S2MM_DEPTH (S2MM_DEPTH), .MM2S_DEPTH (MM2S_DEPTH)
+    ) dut (
+        .devicemode      (devicemode),
+        .s2mm_dstaddr    (s2mm_dstaddr),
+        .s2mm_srcaddr    (s2mm_srcaddr),
+        .s2mm_cmd        (s2mm_cmd),
+        .umi_nreset      (nreset),
+        .umi_clk         (clk),
+        .umi_in_valid    (umi_in_valid),
+        .umi_in_cmd      (umi_in_cmd),
+        .umi_in_dstaddr  (umi_in_dstaddr),
+        .umi_in_srcaddr  (umi_in_srcaddr),
+        .umi_in_data     (umi_in_data),
+        .umi_in_ready    (umi_in_ready),
+        .umi_out_valid   (umi_out_valid),
+        .umi_out_cmd     (umi_out_cmd),
+        .umi_out_dstaddr (umi_out_dstaddr),
+        .umi_out_srcaddr (umi_out_srcaddr),
+        .umi_out_data    (umi_out_data),
+        .umi_out_ready   (umi_out_ready),
+        .usi_clk         (clk),
+        .usi_nreset      (nreset),
+        .usi_out_valid   (usi_out_valid),
+        .usi_out_last    (usi_out_last),
+        .usi_out_data    (usi_out_data),
+        .usi_out_ready   (usi_out_ready),
+        .usi_in_valid    (usi_in_valid),
+        .usi_in_last     (usi_in_last),
+        .usi_in_data     (usi_in_data),
+        .usi_in_ready    (usi_in_ready)
+    );
+
+    // ----------------------------------------------------------------
+    // observed faces: the faults corrupt what the checkers and the USI
+    // laws see, never the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_VALID
+    wire obs_umi_valid = umi_out_valid & ~f_glitch;
+`else
+    wire obs_umi_valid = umi_out_valid;
+`endif
+
+`ifdef FV_FAULT_DATA
+    wire [DW-1:0] obs_umi_data = umi_out_data ^ {DW{f_glitch}};
+`else
+    wire [DW-1:0] obs_umi_data = umi_out_data;
+`endif
+
+`ifdef FV_FAULT_USI_HOLD
+    wire obs_usi_valid = usi_out_valid & ~f_glitch;
+`else
+    wire obs_usi_valid = usi_out_valid;
+`endif
+
+`ifdef FV_FAULT_USI_STABLE
+    wire [DW-1:0] obs_usi_data = usi_out_data ^ {DW{f_glitch}};
+`else
+    wire [DW-1:0] obs_usi_data = usi_out_data;
+`endif
+
+    // ----------------------------------------------------------------
+    // the two UMI faces, both faces of one rule list
+    // ----------------------------------------------------------------
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (1),                      // environment: assume legal input
+        .RULE_EN (RULE_EN)
+    ) env_umi_in (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (umi_in_valid),
+        .ready   (umi_in_ready),
+        .cmd     (umi_in_cmd),
+        .dstaddr (umi_in_dstaddr),
+        .srcaddr (umi_in_srcaddr),
+        .data    (umi_in_data)
+    );
+
+    umi_handshake_checker #(
+        .CW (CW), .AW (AW), .DW (DW),
+        .ASSUME (0),                      // requirement: assert legal output
+        .RULE_EN (RULE_EN)
+    ) chk_umi_out (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (obs_umi_valid),
+        .ready   (umi_out_ready),
+        .cmd     (umi_out_cmd),
+        .dstaddr (umi_out_dstaddr),
+        .srcaddr (umi_out_srcaddr),
+        .data    (obs_umi_data)
+    );
+
+    // ----------------------------------------------------------------
+    // the two USI faces: rules 2 and 3 written out for a stream beat,
+    // which carries DATA and LAST rather than a UMI packet
+    // ----------------------------------------------------------------
+    reg        usi_in_valid_q;
+    reg        usi_in_last_q;
+    reg [DW:0] usi_in_bundle_q;
+    reg        usi_in_ready_q;
+    always @(posedge clk) begin
+        usi_in_valid_q  <= usi_in_valid;
+        usi_in_ready_q  <= usi_in_ready;
+        usi_in_bundle_q <= {usi_in_last, usi_in_data};
+    end
+
+    // the source is required to obey the same discipline as any UMI
+    // driver: hold the offer, hold the payload
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset)
+            if (usi_in_valid_q & ~usi_in_ready_q) begin
+                assume (usi_in_valid);
+                assume ({usi_in_last, usi_in_data} == usi_in_bundle_q);
+            end
+
+    reg        usi_out_valid_q;
+    reg        usi_out_ready_q;
+    reg [DW:0] usi_out_bundle_q;
+    always @(posedge clk) begin
+        usi_out_valid_q  <= obs_usi_valid;
+        usi_out_ready_q  <= usi_out_ready;
+        usi_out_bundle_q <= {usi_out_last, obs_usi_data};
+    end
+
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset)
+            if (usi_out_valid_q & ~usi_out_ready_q) begin
+                a_usi_out_hold : assert (obs_usi_valid);
+                a_usi_out_stable : assert ({usi_out_last, obs_usi_data}
+                                           == usi_out_bundle_q);
+            end
+
+    // ----------------------------------------------------------------
+    // witnesses: no face is passing on a link that never moves a beat
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            c_str_umi_xfer : cover (obs_umi_valid & umi_out_ready);
+            c_str_umi_wait : cover (obs_umi_valid & ~umi_out_ready);
+            c_str_usi_xfer : cover (obs_usi_valid & usi_out_ready);
+            c_str_usi_wait : cover (obs_usi_valid & ~usi_out_ready);
+            c_str_usi_last : cover (obs_usi_valid & usi_out_ready
+                                    & usi_out_last);
+            c_str_umi_bp   : cover (~umi_in_ready);
+            c_str_usi_bp   : cover (~usi_in_ready);
+            // both operating modes really are explored
+            c_str_device   : cover (devicemode & obs_usi_valid);
+            c_str_link     : cover (~devicemode & obs_umi_valid);
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/formal/sumi/fv_umi_switch.sv
+++ b/umi/formal/sumi/fv_umi_switch.sv
@@ -63,6 +63,7 @@
  *   switch:bmc            M=1, output handshake, bounded
  *   switch:bmc_m2         M=2, the same handshake with the ready merge
  *                         active across two outputs
+ *   switch:cover_m2       witnesses at M=2: expect all reached
  *   switch:cover          witnesses: expect all reached
  *   switch:fault_valid    must FAIL, chk_out.RULE2_valid_hold
  *

--- a/umi/formal/sumi/fv_umi_switch.sv
+++ b/umi/formal/sumi/fv_umi_switch.sv
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * - Proves the NxM switch keeps the SUMI handshake on each output, and
+ *   pins down what its input-ready merge does once there is more than
+ *   one output.
+ *
+ * THE READY MERGE, AND A CLAIM THE TOOL REFUTED. umi_switch builds one
+ * umi_mux per output and ANDs every mux's per-input ready together
+ * (umi_switch.v:121-127):
+ *
+ *     umi_in_ready[n] = 1;
+ *     for each output m:  umi_in_ready[n] &= umi_ready[n + N*m];
+ *
+ * A mux raises ready only for the input it has selected (umi_mux.v:98,
+ * umi_in_ready = sel_oh & {N{umi_out_ready}}), so reading the source
+ * suggests an input asking for one output can never be accepted once
+ * M > 1: some other mux has not selected it and contributes a zero.
+ *
+ * That is written here because it is wrong, and the harness is what
+ * showed it. An assertion saying umi_in_ready stays zero under unicast
+ * traffic FAILS in three cycles: a mux that stalled while granting an
+ * input holds that selection in stalled_input (umi_mux.v:89-91), so its
+ * ready can still be high for an input that is no longer asking it.
+ * Acceptance therefore depends on the stalled-grant history of every
+ * other output, which is not a property of the traffic at all.
+ *
+ * No law here claims the merge is right or wrong. What the rows do is
+ * pin the handshake on both arms and witness that traffic moves, so a
+ * change in that history-dependent behaviour shows up as a diff.
+ *
+ * WHAT IS PROVEN, both arms:
+ *   RULE2_valid_hold / RULE3_*_stable   the handshake on every output
+ *                     port, with each input's payload constrained
+ *                     legal by the same checker in its ASSUME face
+ *
+ * BOUNDED. The arbiter thermometer inside each mux and the mux's
+ * captured stalled_input are not observable from these ports -- the
+ * fence fv_umi_mux already documents -- so induction starts from states
+ * no trace reaches. These rows are bmc.
+ *
+ * Outside these laws: which input wins when several compete, fairness,
+ * and progress. MASK is left at its default of zero, so no path is
+ * statically disabled.
+ *
+ * ROWS (tests/sumi/test_formal_sc.py):
+ *   switch:bmc            M=1, output handshake, bounded
+ *   switch:bmc_m2         M=2, the same handshake with the ready merge
+ *                         active across two outputs
+ *   switch:cover          witnesses: expect all reached
+ *   switch:fault_valid    must FAIL, chk_out.RULE2_valid_hold
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module fv_umi_switch #(
+    parameter N  = 2,
+    parameter M  = 1,
+    parameter CW = 32,
+    parameter AW = 64,
+    parameter DW = 64,
+    parameter [5:0] RULE_EN = 6'h3F
+) (
+    input wire clk
+);
+
+    // ----------------------------------------------------------------
+    // reset: free, but asserted at time zero (grounds all history)
+    // ----------------------------------------------------------------
+    (* anyseq *) wire nreset;
+    reg f_past_exists = 1'b0;
+    always @(posedge clk)
+        f_past_exists <= 1'b1;
+    always @(*)
+        if (!f_past_exists)
+            assume (!nreset);
+
+    reg past_nreset = 1'b0;
+    always @(posedge clk)
+        past_nreset <= nreset;
+
+    // ----------------------------------------------------------------
+    // free stimulus
+    // ----------------------------------------------------------------
+    (* anyseq *) wire [N*M-1:0] in_valid;
+    (* anyseq *) wire [N*CW-1:0] in_cmd;
+    (* anyseq *) wire [N*AW-1:0] in_dstaddr;
+    (* anyseq *) wire [N*AW-1:0] in_srcaddr;
+    (* anyseq *) wire [N*DW-1:0] in_data;
+    (* anyseq *) wire [M-1:0]   out_ready;
+
+    wire [N-1:0]    in_ready;
+    wire [M-1:0]    out_valid;
+    wire [M*CW-1:0] out_cmd;
+    wire [M*AW-1:0] out_dstaddr;
+    wire [M*AW-1:0] out_srcaddr;
+    wire [M*DW-1:0] out_data;
+
+    umi_switch #(
+        .N (N), .M (M), .MASK ({(M*N){1'b0}}),
+        .DW (DW), .CW (CW), .AW (AW)
+    ) dut (
+        .clk             (clk),
+        .nreset          (nreset),
+        .arbmode         (2'b10),        // round robin, per umi_arbiter.v:63
+        .arbmask         ({(N*M){1'b0}}),
+        .umi_in_valid    (in_valid),
+        .umi_in_cmd      (in_cmd),
+        .umi_in_dstaddr  (in_dstaddr),
+        .umi_in_srcaddr  (in_srcaddr),
+        .umi_in_data     (in_data),
+        .umi_in_ready    (in_ready),
+        .umi_out_valid   (out_valid),
+        .umi_out_cmd     (out_cmd),
+        .umi_out_dstaddr (out_dstaddr),
+        .umi_out_srcaddr (out_srcaddr),
+        .umi_out_data    (out_data),
+        .umi_out_ready   (out_ready)
+    );
+
+    // ----------------------------------------------------------------
+    // unicast: each input asks for at most one output, which is how a
+    // switch is ordinarily driven
+    // ----------------------------------------------------------------
+    wire [N-1:0] want;          // input n is asking for something
+    wire [N-1:0] multi;         // input n is asking for more than one
+    genvar gn, gm;
+    generate
+        for (gn = 0; gn < N; gn = gn + 1) begin : g_want
+            wire [M-1:0] asks;
+            for (gm = 0; gm < M; gm = gm + 1) begin : g_asks
+                assign asks[gm] = in_valid[gm*N + gn];
+            end
+            assign want[gn]  = |asks;
+            assign multi[gn] = |(asks & (asks - {{(M-1){1'b0}}, 1'b1}));
+        end
+    endgenerate
+
+    always @(*)
+        m_sw_unicast : assume (multi == {N{1'b0}});
+
+    // ----------------------------------------------------------------
+    // observed outputs: the fault corrupts what the checker sees, never
+    // the DUT. No RTL is copied or edited.
+    // ----------------------------------------------------------------
+    (* anyseq *) wire f_glitch;
+
+`ifdef FV_FAULT_VALID
+    wire [M-1:0] obs_valid = out_valid & ~{M{f_glitch}};
+`else
+    wire [M-1:0] obs_valid = out_valid;
+`endif
+
+    // ----------------------------------------------------------------
+    // the handshake on every output, and legality on every input
+    // ----------------------------------------------------------------
+    generate
+        for (gn = 0; gn < N; gn = gn + 1) begin : g_env
+            umi_handshake_checker #(
+                .CW (CW), .AW (AW), .DW (DW),
+                .ASSUME (1),              // environment: legal inputs
+                .RULE_EN (RULE_EN)
+            ) env_in (
+                .clk     (clk),
+                .nreset  (nreset),
+                .valid   (want[gn]),
+                .ready   (in_ready[gn]),
+                .cmd     (in_cmd[gn*CW +: CW]),
+                .dstaddr (in_dstaddr[gn*AW +: AW]),
+                .srcaddr (in_srcaddr[gn*AW +: AW]),
+                .data    (in_data[gn*DW +: DW])
+            );
+        end
+
+        for (gm = 0; gm < M; gm = gm + 1) begin : g_chk
+            umi_handshake_checker #(
+                .CW (CW), .AW (AW), .DW (DW),
+                .ASSUME (0),              // requirement: legal outputs
+                .RULE_EN (RULE_EN)
+            ) chk_out (
+                .clk     (clk),
+                .nreset  (nreset),
+                .valid   (obs_valid[gm]),
+                .ready   (out_ready[gm]),
+                .cmd     (out_cmd[gm*CW +: CW]),
+                .dstaddr (out_dstaddr[gm*AW +: AW]),
+                .srcaddr (out_srcaddr[gm*AW +: AW]),
+                .data    (out_data[gm*DW +: DW])
+            );
+        end
+    endgenerate
+
+    // ----------------------------------------------------------------
+    // witnesses
+    // ----------------------------------------------------------------
+`ifdef FORMAL
+    always @(posedge clk)
+        if (f_past_exists & nreset & past_nreset) begin
+            // an input asking with every output ready, and an input
+            // actually accepted: together these say the merge does let
+            // traffic through, which is what the refuted assertion got
+            // wrong
+            c_sw_want   : cover (|want & (&out_ready));
+            c_sw_outxfer: cover (|(obs_valid & out_ready));
+            c_sw_outwait: cover (|(obs_valid & ~out_ready));
+            c_sw_accept : cover (|in_ready);
+        end
+`endif
+
+endmodule
+
+`default_nettype wire

--- a/umi/lumi/rtl/lumi_tx_ready.v
+++ b/umi/lumi/rtl/lumi_tx_ready.v
@@ -122,15 +122,15 @@ module lumi_tx_ready
     reg [AW-1:0]    umi_out_dstaddr_r;
     reg [AW-1:0]    umi_out_srcaddr_r;
 
-    always @(posedge clk or negedge nreset)
+    always @(posedge clk)
         if (umi_out_valid & umi_out_ready)
             umi_out_cmd_r <= umi_out_cmd;
 
-    always @(posedge clk or negedge nreset)
+    always @(posedge clk)
         if (umi_out_valid & umi_out_ready)
             umi_out_dstaddr_r <= umi_out_dstaddr;
 
-    always @(posedge clk or negedge nreset)
+    always @(posedge clk)
         if (umi_out_valid & umi_out_ready)
             umi_out_srcaddr_r <= umi_out_srcaddr;
 

--- a/umi/sumi/umi_arbiter/rtl/umi_arbiter.v
+++ b/umi/sumi/umi_arbiter/rtl/umi_arbiter.v
@@ -26,7 +26,7 @@ module umi_arbiter #(parameter N = 4,    // number of inputs
    (// controls
     input          clk,
     input          nreset,
-    input [1:0]    mode,     // [00]=priority,[01]=roundrobin,[1x]=reserved
+    input [1:0]    mode,     // [10]=roundrobin, all others=priority
     input [N-1:0]  mask,     // 1 = disable request, 0 = enable request
     input [N-1:0]  requests, // incoming requests
     output [N-1:0] grants    // outgoing grants

--- a/umi/sumi/umi_checker/rtl/umi_frame_checker.sv
+++ b/umi/sumi/umi_checker/rtl/umi_frame_checker.sv
@@ -48,10 +48,13 @@
  *   FRAME_da_cont       a continuation beat's DA is the running address:
  *                      the previous DA advanced by the bytes the
  *                      previous beat carried. README 4.1.1 rule 4,
- *                      "only the destination address increments".
+ *                      DA_out[i] := DA_out[i-1] + (2^SIZE)*(LEN_out[i-1]+1).
  *   FRAME_sa_cont       and its SA likewise, README 4.1.1 rule 5 -- the
  *                      rule umi_txn_checker records as
- *                      observed-but-not-asserted.
+ *                      observed-but-not-asserted. Rule 5 applies to
+ *                      split REQUESTS; a response has no SA field, so
+ *                      switch this rule off (RULE_EN[4]) on a channel
+ *                      carrying responses.
  *   FRAME_msgbytes      the bytes accumulated over a message never
  *                      exceed MAX_MSG_BYTES (README 2, 32768).
  *

--- a/umi/sumi/umi_checker/rtl/umi_frame_checker.sv
+++ b/umi/sumi/umi_checker/rtl/umi_frame_checker.sv
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright 2026 Zero ASIC Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----
+ *
+ * Documentation:
+ *
+ * Intra-message framing checker for ONE UMI channel.
+ *
+ * umi_txn_checker judges the framing of RESPONSE messages, and says so
+ * in its own header: request beats are observed to populate its
+ * outstanding tracker, but their framing is not asserted, so a host
+ * emitting broken multi-beat requests is not caught. This module is
+ * that missing half. It watches a single channel and holds the beats of
+ * one message to README 4.1.1, which makes it usable on a request
+ * channel -- the case nothing covered before -- and equally on any
+ * other channel whose framing is worth checking.
+ *
+ * It carries no outstanding tracker and pairs nothing with anything: it
+ * is about the beats WITHIN one message, not about requests and
+ * responses matching up. That keeps it small enough to bind to every
+ * port of a fabric.
+ *
+ * THE RULES, with their README anchors. All of them are conditioned on
+ * a CONTINUATION beat -- one accepted while a message is already open,
+ * meaning an earlier beat of it went by with EOM low. A message carried
+ * in a single beat has no intra-message framing and nothing here
+ * constrains it.
+ *
+ *   FRAME_size_stable   SIZE is the same on every beat of a message.
+ *                      README 4.1.1 rule 2: a split copies the fields.
+ *   FRAME_opcode_stable the opcode likewise -- the beats of one message
+ *                      are all the same message (README 4.1.1 rule 2).
+ *   FRAME_fields_stable QOS, PROT and EOF likewise (README 3.3.4,
+ *                      3.3.5, 3.3.7).
+ *   FRAME_da_cont       a continuation beat's DA is the running address:
+ *                      the previous DA advanced by the bytes the
+ *                      previous beat carried. README 4.1.1 rule 4,
+ *                      "only the destination address increments".
+ *   FRAME_sa_cont       and its SA likewise, README 4.1.1 rule 5 -- the
+ *                      rule umi_txn_checker records as
+ *                      observed-but-not-asserted.
+ *   FRAME_msgbytes      the bytes accumulated over a message never
+ *                      exceed MAX_MSG_BYTES (README 2, 32768).
+ *
+ * Bytes come from the command word the way README 3.3.2 and 3.3.3
+ * define them: (LEN+1) << SIZE.
+ *
+ * ADDRESS ARITHMETIC IS MODULAR. The running address is computed in AW
+ * bits and wraps. The specification does not say what a split message
+ * does at the top of the address space, so this module follows the
+ * arithmetic rather than inventing a rule; a message that wraps is
+ * checked against the wrapped address.
+ *
+ * ASSUME. As in the other checkers here: ASSUME=0 asserts the rules on
+ * a channel being judged, ASSUME=1 assumes them on a channel being
+ * driven, from one rule list so the two faces cannot drift apart.
+ *
+ * RULE_EN. One bit per rule, LSB first, so an adopter who reads one
+ * rule differently can switch it off without losing the rest:
+ *
+ *    0  FRAME_size_stable     3  FRAME_da_cont
+ *    1  FRAME_opcode_stable   4  FRAME_sa_cont
+ *    2  FRAME_fields_stable   5  FRAME_msgbytes
+ *
+ * Outside this module: whether a message ever ends (no liveness
+ * property here), whether the payload is right, and anything that needs
+ * a second channel.
+ *
+ ******************************************************************************/
+
+`default_nettype none
+
+module umi_frame_checker #(
+    parameter CW = 32,                       // command width
+    parameter AW = 64,                       // address width
+    parameter DW = 256,                      // data width
+    parameter [31:0] MAX_MSG_BYTES = 32768,  // per-message byte ceiling
+    parameter ASSUME = 0,                    // 0: assert the rules, 1: assume
+    parameter [5:0] RULE_EN = 6'h3F          // per-rule enables
+) (
+    input wire          clk,
+    input wire          nreset,
+    input wire          valid,
+    input wire          ready,
+    input wire [CW-1:0] cmd,
+    input wire [AW-1:0] dstaddr,
+    input wire [AW-1:0] srcaddr,
+    input wire [DW-1:0] data
+);
+
+`include "umi_messages.vh"
+
+    // ----------------------------------------------------------------
+    // this beat
+    // ----------------------------------------------------------------
+    wire        beat = valid & ready;
+    wire        eom  = cmd[UMI_EOM_BIT];
+    wire [2:0]  size = cmd[UMI_SIZE_MSB:UMI_SIZE_LSB];
+    wire [7:0]  len  = cmd[UMI_LEN_MSB:UMI_LEN_LSB];
+
+    // (LEN+1) << SIZE, README 3.3.2 and 3.3.3. Computed twice at two
+    // widths on purpose: the byte ceiling is a 32-bit comparison, while
+    // the running address must be added at AW, and slicing the 32-bit
+    // form down to AW is out of range whenever AW is wider than 32.
+    wire [31:0]   bytes    = ({24'd0, len} + 32'd1) << size;
+    wire [AW-1:0] bytes_aw = ({{(AW-8){1'b0}}, len}
+                              + {{(AW-1){1'b0}}, 1'b1}) << size;
+
+    // ----------------------------------------------------------------
+    // the message in progress
+    // ----------------------------------------------------------------
+    reg          open_msg;     // a message is open: an earlier beat had EOM low
+    reg [CW-1:0] first_cmd;    // the fields every later beat must repeat
+    reg [AW-1:0] next_da;      // where the next beat must be addressed
+    reg [AW-1:0] next_sa;
+    reg [31:0]   acc_bytes;    // bytes carried so far, this message
+
+    wire [31:0] tot_bytes = acc_bytes + bytes;
+
+    always @(posedge clk or negedge nreset)
+        if (!nreset) begin
+            open_msg  <= 1'b0;
+            first_cmd <= {CW{1'b0}};
+            next_da   <= {AW{1'b0}};
+            next_sa   <= {AW{1'b0}};
+            acc_bytes <= 32'd0;
+        end else if (beat) begin
+            open_msg  <= ~eom;
+            if (!open_msg)
+                first_cmd <= cmd;
+            next_da   <= dstaddr + bytes_aw;
+            next_sa   <= srcaddr + bytes_aw;
+            acc_bytes <= eom ? 32'd0 : tot_bytes;
+        end
+
+    // a beat accepted while a message is already open
+    wire cont = beat & open_msg;
+
+    // ----------------------------------------------------------------
+    // the rules, one list, two faces
+    // ----------------------------------------------------------------
+    wire fields_ok = (cmd[UMI_QOS_MSB:UMI_QOS_LSB]
+                      == first_cmd[UMI_QOS_MSB:UMI_QOS_LSB])
+                   & (cmd[UMI_PROT_MSB:UMI_PROT_LSB]
+                      == first_cmd[UMI_PROT_MSB:UMI_PROT_LSB])
+                   & (cmd[UMI_EOF_BIT] == first_cmd[UMI_EOF_BIT]);
+    wire size_ok   = (size == first_cmd[UMI_SIZE_MSB:UMI_SIZE_LSB]);
+    wire opcode_ok = (cmd[UMI_OPCODE_MSB:UMI_OPCODE_LSB]
+                      == first_cmd[UMI_OPCODE_MSB:UMI_OPCODE_LSB]);
+    wire da_ok     = (dstaddr == next_da);
+    wire sa_ok     = (srcaddr == next_sa);
+    wire bytes_ok  = (tot_bytes <= MAX_MSG_BYTES);
+
+`ifdef FORMAL
+    generate
+        if (ASSUME == 0) begin : g_assert
+            always @(posedge clk)
+                if (nreset & cont) begin
+                    if (RULE_EN[0])
+                        FRAME_size_stable : assert (size_ok);
+                    if (RULE_EN[1])
+                        FRAME_opcode_stable : assert (opcode_ok);
+                    if (RULE_EN[2])
+                        FRAME_fields_stable : assert (fields_ok);
+                    if (RULE_EN[3])
+                        FRAME_da_cont : assert (da_ok);
+                    if (RULE_EN[4])
+                        FRAME_sa_cont : assert (sa_ok);
+                    if (RULE_EN[5])
+                        FRAME_msgbytes : assert (bytes_ok);
+                end
+        end else begin : g_assume
+            always @(posedge clk)
+                if (nreset & cont) begin
+                    if (RULE_EN[0])
+                        FRAME_size_stable : assume (size_ok);
+                    if (RULE_EN[1])
+                        FRAME_opcode_stable : assume (opcode_ok);
+                    if (RULE_EN[2])
+                        FRAME_fields_stable : assume (fields_ok);
+                    if (RULE_EN[3])
+                        FRAME_da_cont : assume (da_ok);
+                    if (RULE_EN[4])
+                        FRAME_sa_cont : assume (sa_ok);
+                    if (RULE_EN[5])
+                        FRAME_msgbytes : assume (bytes_ok);
+                end
+        end
+    endgenerate
+
+    // anti-vacuity: a multi-beat message really is exercised
+    always @(posedge clk)
+        if (nreset) begin
+            FRAME_open  : cover (beat & ~eom);
+            FRAME_cont  : cover (cont);
+            FRAME_close : cover (cont & eom);
+        end
+`else
+    // the same rules in a 4-state simulator
+    always @(posedge clk)
+        if (nreset & cont & (ASSUME == 0)) begin
+            if (RULE_EN[0] && (size_ok !== 1'b1))
+                $error("UMI-FRAME size %m: SIZE changed inside a message (README 4.1.1)");
+            if (RULE_EN[1] && (opcode_ok !== 1'b1))
+                $error("UMI-FRAME opcode %m: opcode changed inside a message (README 4.1.1)");
+            if (RULE_EN[2] && (fields_ok !== 1'b1))
+                $error("UMI-FRAME fields %m: QOS/PROT/EOF changed inside a message (README 4.1.1)");
+            if (RULE_EN[3] && (da_ok !== 1'b1))
+                $error("UMI-FRAME da %m: DA is not the running address (README 4.1.1 rule 4)");
+            if (RULE_EN[4] && (sa_ok !== 1'b1))
+                $error("UMI-FRAME sa %m: SA is not the running address (README 4.1.1 rule 5)");
+            if (RULE_EN[5] && (bytes_ok !== 1'b1))
+                $error("UMI-FRAME msgbytes %m: message exceeds MAX_MSG_BYTES (README 2)");
+        end
+`endif
+
+    // data is not inspected: framing is a command-word property
+    wire _unused_data = |{1'b0, data};
+
+endmodule
+
+`default_nettype wire

--- a/umi/sumi/umi_checker/testbench/tb_umi_cmd_checker.sv
+++ b/umi/sumi/umi_checker/testbench/tb_umi_cmd_checker.sv
@@ -22,6 +22,10 @@
  * working inject run prints the UMI-CMD $error line and no "TB FAIL"
  * line; a missed detection prints "TB FAIL" before the nonzero exit.
  *
+ * No message printed by this testbench repeats the checker's error text.
+ * If it did, the caller's search for that text would match the
+ * testbench's own output and the run would pass with the checker silent.
+ *
  * Run (Icarus, from this directory):
  *   iverilog -g2012 -I ../../include -o tb_umi_cmd_checker.vvp \
  *            tb_umi_cmd_checker.sv ../rtl/umi_cmd_checker.sv
@@ -162,7 +166,7 @@ module tb_umi_cmd_checker;
             $display("TB PASS: legal sequence, checker silent");
             $finish;
         end
-        $display("TB DONE: inject run complete (the UMI-CMD CMD-1 error above is the expected result)");
+        $display("TB DONE: inject run complete (the checker error above is the expected result)");
         $fatal(0, "expected-violation run: nonzero exit by design");
     end
 

--- a/umi/sumi/umi_checker/testbench/tb_umi_frame_checker.sv
+++ b/umi/sumi/umi_checker/testbench/tb_umi_frame_checker.sv
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Self-test for umi_frame_checker in SIMULATION (no formal tools).
+ *
+ * The testbench drives one SUMI REQUEST channel -- the checker is a
+ * passive observer of a single channel, so no DUT is needed to
+ * demonstrate it, and a request channel is the case umi_txn_checker
+ * leaves unasserted. It plays a single-beat message (which has no
+ * intra-message framing and must therefore be ignored) followed by a
+ * three-beat REQ_WR message split word-per-beat. Two runs:
+ *
+ *   clean (default) : the three beats repeat SIZE, opcode, QOS, PROT and
+ *                     EOF, and walk DA and SA forward by the eight bytes
+ *                     each beat carries. Expect: "TB PASS", exit 0, no
+ *                     checker output at all.
+ *   +inject         : the same message, but the CLOSING beat carries
+ *                     SIZE=2 where the message opened at SIZE=3 -- the
+ *                     mid-message SIZE mutation, a FRAME_size_stable
+ *                     violation. Expect: one "UMI-FRAME size" error.
+ *
+ * The mutation is placed on the closing beat on purpose. The running
+ * address a beat is judged against is derived from the PREVIOUS beat, so
+ * changing SIZE last cannot disturb the address laws, and the byte total
+ * only shrinks. Exactly one rule fires, which is what makes the run
+ * evidence about that rule rather than about the checker in general.
+ *
+ * The testbench carries its own reading of README 4.1.1 -- an
+ * independent running-address, field-stability and byte-ceiling model,
+ * advanced beat by beat -- and every beat declares whether it is meant
+ * to be legal. If the model and the declaration disagree the run prints
+ * "TB FAIL" and ends in $fatal. That is what stops an injected beat from
+ * silently being legal after all: without it, a mutation that turns out
+ * not to violate anything would leave the checker correctly silent and
+ * the run would look like a missed detection.
+ *
+ * Exit codes gate pass/fail, but the exit code alone cannot distinguish
+ * a working checker from a broken one: the inject run ends in $fatal by
+ * design, and a run whose checker missed the beat exits nonzero the same
+ * way. The caller must ALSO check the output text -- a working inject
+ * run prints the checker's own "UMI-FRAME size" line and no "TB FAIL"
+ * line. No message printed by this testbench repeats that text, so the
+ * text in the log can only have come from the checker.
+ *
+ * Run (Icarus, from this directory):
+ *   iverilog -g2012 -I ../../include -o tb_umi_frame_checker.vvp \
+ *            tb_umi_frame_checker.sv ../rtl/umi_frame_checker.sv
+ *   vvp tb_umi_frame_checker.vvp             # expect: TB PASS, exit 0
+ *   vvp tb_umi_frame_checker.vvp +inject     # expect: size error, exit 1
+ ******************************************************************************/
+
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_umi_frame_checker;
+
+    localparam CW = 32;
+    localparam AW = 64;
+    localparam DW = 64;   // 8 bytes/beat: SIZE=3 gives exactly one word/beat
+
+    localparam [31:0] MAX_MSG_BYTES = 32768;
+
+    // command words, REQ_WR (5'h03) with LEN=0, QOS=0, PROT=0, EOF=0.
+    // SIZE is bits [7:5] and EOM is bit 22.
+    localparam [CW-1:0] CMD_OPEN     = 32'h0000_0063;  // SIZE=3, EOM=0
+    localparam [CW-1:0] CMD_CLOSE    = 32'h0040_0063;  // SIZE=3, EOM=1
+    localparam [CW-1:0] CMD_CLOSE_S2 = 32'h0040_0043;  // SIZE=2, EOM=1
+
+    reg           clk = 1'b0;
+    reg           nreset = 1'b0;
+    reg           valid = 1'b0;
+    reg           ready = 1'b0;
+    reg [CW-1:0]  cmd = '0;
+    reg [AW-1:0]  dstaddr = '0;
+    reg [AW-1:0]  srcaddr = '0;
+    reg [DW-1:0]  data = '0;
+
+    reg inject = 1'b0;
+    integer tb_errors = 0;
+
+    always #5 clk = ~clk;
+
+    umi_frame_checker #(
+        .CW (CW), .AW (AW), .DW (DW), .MAX_MSG_BYTES (MAX_MSG_BYTES)
+    ) chk (
+        .clk     (clk),
+        .nreset  (nreset),
+        .valid   (valid),
+        .ready   (ready),
+        .cmd     (cmd),
+        .dstaddr (dstaddr),
+        .srcaddr (srcaddr),
+        .data    (data)
+    );
+
+    // ----------------------------------------------------------------
+    // the testbench's own model of README 4.1.1, advanced independently
+    // ----------------------------------------------------------------
+    reg           mdl_open = 1'b0;
+    reg [CW-1:0]  mdl_first = '0;
+    reg [AW-1:0]  mdl_next_da = '0;
+    reg [AW-1:0]  mdl_next_sa = '0;
+    reg [31:0]    mdl_acc = 32'd0;
+
+    // drive one beat and require the model's verdict to match t_legal
+    task drive_beat(input [CW-1:0] t_cmd,
+                    input [AW-1:0] t_da,
+                    input [AW-1:0] t_sa,
+                    input [DW-1:0] t_data,
+                    input          t_legal);
+        reg [2:0]    t_size;
+        reg [7:0]    t_len;
+        reg [31:0]   t_bytes;
+        reg [AW-1:0] t_bytes_aw;
+        reg          beat_ok;
+        begin
+            // entered at a negedge: the checker's shadow registers still
+            // hold the values its NEXT posedge will judge this beat by
+            valid   = 1'b1;
+            ready   = 1'b1;
+            cmd     = t_cmd;
+            dstaddr = t_da;
+            srcaddr = t_sa;
+            data    = t_data;
+
+            t_size     = t_cmd[7:5];
+            t_len      = t_cmd[15:8];
+            t_bytes    = ({24'd0, t_len} + 32'd1) << t_size;   // README 3.3.2/3.3.3
+            t_bytes_aw = {{(AW-32){1'b0}}, t_bytes};
+
+            // a beat that opens a message is unconstrained; a continuation
+            // must repeat the fields and land on the running address
+            beat_ok = ~mdl_open ? 1'b1
+                    : ((t_size        == mdl_first[7:5])
+                    &  (t_cmd[4:0]    == mdl_first[4:0])
+                    &  (t_cmd[19:16]  == mdl_first[19:16])
+                    &  (t_cmd[21:20]  == mdl_first[21:20])
+                    &  (t_cmd[23]     == mdl_first[23])
+                    &  (t_da          == mdl_next_da)
+                    &  (t_sa          == mdl_next_sa)
+                    &  ((mdl_acc + t_bytes) <= MAX_MSG_BYTES));
+
+            if (beat_ok !== t_legal) begin
+                tb_errors = tb_errors + 1;
+                $display("TB FAIL: beat verdict mismatch: cmd=%h da=%h sa=%h (%s beat) model says %s, expected %s",
+                         t_cmd, t_da, t_sa, mdl_open ? "cont" : "opening",
+                         beat_ok ? "legal" : "ILLEGAL",
+                         t_legal ? "legal" : "ILLEGAL");
+            end
+
+            @(posedge clk);        // checker samples the beat and judges it
+
+            // advance the model the way the checker advances its shadow:
+            // first_cmd is captured from the beat that OPENS a message
+            if (!mdl_open)
+                mdl_first = t_cmd;
+            mdl_open    = ~t_cmd[22];
+            mdl_next_da = t_da + t_bytes_aw;
+            mdl_next_sa = t_sa + t_bytes_aw;
+            mdl_acc     = t_cmd[22] ? 32'd0 : (mdl_acc + t_bytes);
+
+            @(negedge clk);
+            valid = 1'b0;
+            ready = 1'b0;
+        end
+    endtask
+
+    initial begin
+        if ($test$plusargs("inject"))
+            inject = 1'b1;
+
+        // reset: no beats offered
+        repeat (2) @(negedge clk);
+        nreset = 1'b1;
+        @(negedge clk);
+
+        // a message carried in ONE beat: no intra-message framing exists,
+        // so nothing here may be judged however the fields fall
+        drive_beat(CMD_CLOSE,
+                   64'h0000_0000_0000_3000,
+                   64'h0000_0000_0000_4000,
+                   64'hA5A5_A5A5_A5A5_A5A5, 1'b1);
+
+        // a three-beat message, 8 bytes per beat, opening at SIZE=3
+        drive_beat(CMD_OPEN,
+                   64'h0000_0000_0000_2000,
+                   64'h0000_0000_0000_1000,
+                   64'h0011_2233_4455_6677, 1'b1);
+
+        // continuation: DA and SA have both advanced by 8
+        drive_beat(CMD_OPEN,
+                   64'h0000_0000_0000_2008,
+                   64'h0000_0000_0000_1008,
+                   64'h8899_AABB_CCDD_EEFF, 1'b1);
+
+        // closing continuation. +inject sends SIZE=2 on a message that
+        // opened at SIZE=3; the addresses still follow from the previous
+        // beat, so the size rule is the only one that can fire.
+        drive_beat(inject ? CMD_CLOSE_S2 : CMD_CLOSE,
+                   64'h0000_0000_0000_2010,
+                   64'h0000_0000_0000_1010,
+                   64'h0F1E_2D3C_4B5A_6978,
+                   inject ? 1'b0 : 1'b1);
+
+        // idle down
+        valid = 1'b0;
+        ready = 1'b0;
+        repeat (2) @(negedge clk);
+
+        if (tb_errors != 0) begin
+            $display("TB FAIL: %0d verdict mismatch(es) between tb and model", tb_errors);
+            $fatal(0, "tb/model mismatch");
+        end
+        if (!inject) begin
+            $display("TB PASS: legal three-beat request message, checker silent");
+            $finish;
+        end
+        $display("TB DONE: inject run complete (the framing error above is the expected result)");
+        $fatal(0, "expected-violation run: nonzero exit by design");
+    end
+
+endmodule
+
+`default_nettype wire

--- a/umi/sumi/umi_checker/testbench/tb_umi_txn_checker.sv
+++ b/umi/sumi/umi_checker/testbench/tb_umi_txn_checker.sv
@@ -32,6 +32,10 @@
  * the UMI-TXN da_cont $error line and no "TB FAIL" line; a missed
  * detection prints "TB FAIL" before the nonzero exit.
  *
+ * No message printed by this testbench repeats the checker's error text.
+ * If it did, the caller's search for that text would match the
+ * testbench's own output and the run would pass with the checker silent.
+ *
  * Run (Icarus, from this directory):
  *   iverilog -g2012 -I ../../include -o tb_umi_txn_checker.vvp \
  *            tb_umi_txn_checker.sv ../rtl/umi_txn_checker.sv
@@ -220,7 +224,7 @@ module tb_umi_txn_checker;
             $display("TB PASS: legal request/response transaction, checker silent");
             $finish;
         end
-        $display("TB DONE: inject run complete (the UMI-TXN da_cont error above is the expected result)");
+        $display("TB DONE: inject run complete (the checker error above is the expected result)");
         $fatal(0, "expected-violation run: nonzero exit by design");
     end
 

--- a/umi/sumi/umi_checker/umi_checker.py
+++ b/umi/sumi/umi_checker/umi_checker.py
@@ -19,8 +19,8 @@ class Checker(UMI):
                          deps=[])
         # the block name is the family home, not a module. test_lint
         # elaborates this fileset under a single top, so point it at the
-        # handshake checker; umi_cmd_checker and umi_txn_checker ship in
-        # the same fileset and are elaborated as tops by the formal lane.
+        # handshake checker; the cmd, txn and frame checkers ship in the
+        # same fileset and are elaborated as tops by the formal lane.
         with self.active_fileset('rtl'):
             self.set_topmodule('umi_handshake_checker')
 

--- a/umi/sumi/umi_checker/umi_checker.py
+++ b/umi/sumi/umi_checker/umi_checker.py
@@ -8,12 +8,14 @@ class Checker(UMI):
       rtl/umi_handshake_checker.sv   README 4.2 ready/valid handshake
       rtl/umi_cmd_checker.sv         CMD-word (command field) legality
       rtl/umi_txn_checker.sv         request/response pairing + framing
+      rtl/umi_frame_checker.sv       intra-message framing, one channel
     """
     def __init__(self):
         super().__init__('umi_checker',
                          files=['rtl/umi_handshake_checker.sv',
                                 'rtl/umi_cmd_checker.sv',
-                                'rtl/umi_txn_checker.sv'],
+                                'rtl/umi_txn_checker.sv',
+                                'rtl/umi_frame_checker.sv'],
                          deps=[])
         # the block name is the family home, not a module. test_lint
         # elaborates this fileset under a single top, so point it at the


### PR DESCRIPTION
Thirteen more formal harnesses, so the SUMI matrix goes from 93 to 214 rows
and now covers 20 of the 21 SUMI blocks. umi_memagent is the one left out;
its atomic unit is textually umi_memif's (proved at the ports here) but
nothing reaches its own ports without a full memory round trip.

Adds a fourth checker, umi_frame_checker, for intra-message framing on a
single channel. umi_txn_checker only asserts the response side, so a host
emitting broken multi-beat requests wasn't caught by anything.

Two RTL changes, both small @RiceShelley  as we discussed:

* umi_arbiter.v comment said [01]=roundrobin, but the logic only rotates
  on 2'b10
* lumi_tx_ready.v had `negedge nreset` on three registers that look like
  they were meant to be plain synchronous ones 

Four rows are pinned as must-fail with nothing injected, meaning the
shipped default config is what breaks the law. The clearest is umi_regif
at SAFE=1: it accepts a second request while the first response is still
standing, so the first answer gets overwritten before anyone takes it.
The others are endpoint capacity, ram response rule 3, and fifoflex
SPLIT=1 byte conservation. If any of them ever goes green the lane says so.

Every fault row names the assertion it has to trip, so an injected bug
that convicts the wrong rule fails the run rather than passing quietly.

    pytest -m formal tests/sumi/test_formal_sc.py    # 214 rows
    pytest tests/sumi/test_checker_testbench.py      # checker sim self-tests
